### PR TITLE
Add recording and session push helper scripts

### DIFF
--- a/claude/recording/session_detect.py
+++ b/claude/recording/session_detect.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""
+Detects the current session log state for the record skill.
+
+Usage:
+    python3 session_detect.py          # normal mode
+    python3 session_detect.py auto     # auto mode (Stop hook) — always returns action=new
+
+Outputs JSON:
+    {"action": "append"|"new"|"ask", "file": "/path/to/latest.md", "latest_date": "YYYY-MM-DD", "today": "YYYY-MM-DD"}
+
+Actions:
+    new    — create a fresh log (auto mode, or no existing logs)
+    append — add to today's existing log
+    ask    — latest log is from a prior day; Claude should prompt the user to choose
+"""
+
+import glob
+import json
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+SESSIONS_DIR = (
+    Path.home() / "git-workspace/claude-workspace/RS-Agent-Planning/Claude Sessions"
+)
+
+
+def main():
+    auto = len(sys.argv) > 1 and sys.argv[1] == "auto"
+    today = datetime.now().strftime("%Y-%m-%d")
+
+    logs = sorted(
+        [f for f in glob.glob(str(SESSIONS_DIR / "*.md")) if "Usage" not in f],
+        key=os.path.getmtime,
+        reverse=True,
+    )
+
+    if not logs:
+        print(json.dumps({"action": "new", "file": None, "latest_date": None, "today": today}))
+        return
+
+    latest = logs[0]
+    latest_date = Path(latest).name[:10]  # YYYY-MM-DD prefix
+
+    if auto:
+        action = "new"
+    elif latest_date == today:
+        action = "append"
+    else:
+        action = "ask"
+
+    print(json.dumps({
+        "action": action,
+        "file": latest,
+        "latest_date": latest_date,
+        "today": today,
+    }))
+
+
+if __name__ == "__main__":
+    main()

--- a/claude/recording/token_usage.py
+++ b/claude/recording/token_usage.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""
+Calculates token usage across all Claude session files and prints a markdown table.
+
+Usage:
+    python3 token_usage.py
+
+Output: markdown table rows + a TOTALS line for the record skill to insert into
+        RS-Agent-Planning/Claude Sessions/Usage/token-usage.md
+"""
+
+import glob
+import json
+import os
+from datetime import datetime
+
+JSONL_GLOBS = [
+    os.path.expanduser("~/.claude/projects/-home-ClaudeSpace/*.jsonl"),
+    os.path.expanduser("~/.claude/sessions/*.jsonl"),
+]
+
+
+def main():
+    total_input = total_output = total_cache_read = total_cache_write = 0
+    sessions = []
+
+    for pattern in JSONL_GLOBS:
+        for f in glob.glob(pattern):
+            sess_input = sess_output = sess_cache_read = sess_cache_write = 0
+            date = datetime.fromtimestamp(os.path.getmtime(f)).strftime("%Y-%m-%d")
+
+            with open(f) as fh:
+                for line in fh:
+                    try:
+                        rec = json.loads(line)
+                        usage = rec.get("usage") or rec.get("message", {}).get("usage", {})
+                        if usage:
+                            sess_input       += usage.get("input_tokens", 0)
+                            sess_output      += usage.get("output_tokens", 0)
+                            sess_cache_read  += usage.get("cache_read_input_tokens", 0)
+                            sess_cache_write += usage.get("cache_creation_input_tokens", 0)
+                    except Exception:
+                        pass
+
+            if sess_input or sess_output:
+                sessions.append((date, os.path.basename(f)[:8], sess_input, sess_output, sess_cache_read, sess_cache_write))
+                total_input       += sess_input
+                total_output      += sess_output
+                total_cache_read  += sess_cache_read
+                total_cache_write += sess_cache_write
+
+    sessions.sort()
+
+    for s in sessions:
+        print(f"| {s[0]} | {s[1]} | {s[2]:,} | {s[3]:,} | {s[4]:,} | {s[5]:,} |")
+
+    print(f"TOTALS {total_input:,} {total_output:,} {total_cache_read:,} {total_cache_write:,}")
+
+
+if __name__ == "__main__":
+    main()

--- a/git-tools/scripts/push_sessions.py
+++ b/git-tools/scripts/push_sessions.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""
+Pushes changes in RS-Agent-Planning and Claude-Project-Tooling to origin/main.
+
+Usage:
+    python3 push_sessions.py --message "Update Claude Sessions and token usage"
+"""
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+REPOS = [
+    Path.home() / "git-workspace/claude-workspace/RS-Agent-Planning",
+    Path.home() / "git-workspace/claude-workspace/Claude-Project-Tooling",
+]
+
+
+def run(args, cwd):
+    result = subprocess.run(args, cwd=cwd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"\nERROR: command failed (exit {result.returncode})")
+        print(f"  CMD:    {' '.join(args)}")
+        if result.stdout.strip():
+            print(f"  STDOUT: {result.stdout.strip()}")
+        if result.stderr.strip():
+            print(f"  STDERR: {result.stderr.strip()}")
+        sys.exit(1)
+    return result.stdout.strip()
+
+
+def has_changes(repo):
+    result = subprocess.run(
+        ["git", "status", "--short"], cwd=repo, capture_output=True, text=True
+    )
+    return bool(result.stdout.strip())
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Push session logs to origin/main")
+    parser.add_argument("--message", required=True, help="Commit message")
+    args = parser.parse_args()
+
+    for repo in REPOS:
+        name = repo.name
+        if not has_changes(repo):
+            print(f"  {name}: nothing to commit — skipped")
+            continue
+
+        run(["git", "add", "-A"], cwd=repo)
+        run(["git", "commit", "-m", args.message], cwd=repo)
+        run(["git", "push", "origin", "main"], cwd=repo)
+        print(f"  {name}: pushed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Extracts mechanical steps from the record skill into standalone scripts, reducing the cognition required each time a session is recorded. Covers log file detection, token usage calculation, and pushing both repos.