### PR TITLE
Add label support to pr workflow

### DIFF
--- a/git-tools/scripts/init_labels.py
+++ b/git-tools/scripts/init_labels.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""
+Initializes the standard label set on a GitHub repository.
+Creates missing labels, skips ones that already exist.
+Removes GitHub default labels not in the standard set.
+
+Usage:
+    python3 init_labels.py --repo OWNER/REPO
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+
+STANDARD_LABELS = [
+    {"name": "Trivial",       "color": "2ecc71", "description": "Can be evaluated quickly"},
+    {"name": "Non-Trivial",   "color": "f1c40f", "description": "Needs a scan through, but is largely harmless"},
+    {"name": "Complex",       "color": "e74c3c", "description": "Requires focused review, a step above Non-Trivial"},
+    {"name": "Integrated",    "color": "7b241c", "description": "Core structural changes likely to break without human review"},
+    {"name": "System",        "color": "607d8b", "description": "Changes to OS, containerization, or automation"},
+    {"name": "Documentation", "color": "0075ca", "description": "Includes documentation updates"},
+    {"name": "Fix",           "color": "8e44ad", "description": "Bug fix or correction"},
+    {"name": "Enhancement",   "color": "a2eeef", "description": "New feature or request"},
+    {"name": "Duplicate",     "color": "cfd3d7", "description": "This issue or pull request already exists"},
+    {"name": "As Designed",   "color": "ffffff", "description": "Intended behavior, not a bug"},
+]
+
+STANDARD_NAMES = {l["name"].lower() for l in STANDARD_LABELS}
+
+REMOVE_DEFAULTS = {"bug", "documentation", "good first issue", "help wanted", "invalid", "question", "wontfix"}
+
+
+def run(args):
+    result = subprocess.run(args, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"\nERROR: command failed (exit {result.returncode})")
+        print(f"  CMD:    {' '.join(args)}")
+        if result.stdout.strip():
+            print(f"  STDOUT: {result.stdout.strip()}")
+        if result.stderr.strip():
+            print(f"  STDERR: {result.stderr.strip()}")
+        sys.exit(1)
+    return result.stdout.strip()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Initialize standard labels on a GitHub repo")
+    parser.add_argument("--repo", required=True, help="Owner/repo (e.g. AndresI19/Claude-Project-Tooling)")
+    args = parser.parse_args()
+
+    existing_raw = run(["gh", "label", "list", "--repo", args.repo, "--json", "name"])
+    existing = {l["name"].lower() for l in json.loads(existing_raw)}
+
+    # Remove unwanted defaults
+    for name in REMOVE_DEFAULTS:
+        if name in existing:
+            run(["gh", "label", "delete", name, "--repo", args.repo, "--yes"])
+            print(f"  Removed: {name}")
+
+    # Create missing standard labels
+    for label in STANDARD_LABELS:
+        if label["name"].lower() not in existing:
+            run(["gh", "label", "create", label["name"],
+                 "--repo", args.repo,
+                 "--color", label["color"],
+                 "--description", label["description"]])
+            print(f"  Created: {label['name']}")
+        else:
+            print(f"  Exists:  {label['name']} — skipped")
+
+    print(f"\nDone. Labels initialized for {args.repo}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/git-tools/scripts/list_prs.py
+++ b/git-tools/scripts/list_prs.py
@@ -3,14 +3,15 @@
 Lists open PRs across all workspace repos, grouped by repo with colored label badges.
 
 Usage:
-    python3 list_prs.py           # ANSI colored table
+    python3 list_prs.py           # ANSI colored table (inline)
+    python3 list_prs.py --window  # Open table in a new Ptyxis terminal window
     python3 list_prs.py --json    # JSON output for programmatic use
 """
 
 import argparse
 import json
 import subprocess
-from datetime import datetime
+import textwrap
 from pathlib import Path
 
 WORKSPACE = Path.home() / "git-workspace/claude-workspace"
@@ -97,23 +98,88 @@ def collect_all(repos):
     return results
 
 
+ID_GRAYS = [
+    {"bg": (90, 90, 90),  "fg": (230, 230, 230)},
+    {"bg": (55, 55, 55),  "fg": (210, 210, 210)},
+]
+
+REPO_BG  = (35, 38, 46)
+REPO_FG  = (160, 190, 230)
+UNDERLINE = "\033[4m"
+NO_UNDER  = "\033[24m"
+
+TITLE_WIDTH = 42
+LABEL_WIDTH = 28
+DATE_WIDTH  = 10
+ID_VISIBLE  = 5   # " 12  " — leading space + 4-char number
+
+# Chars before title column: "  " + id(5) + "  " + date(10) + "  "
+TITLE_INDENT = 2 + ID_VISIBLE + 2 + DATE_WIDTH + 2   # 21
+# Chars before label column
+LABEL_INDENT = TITLE_INDENT + TITLE_WIDTH + 2         # 65
+
+
+def wrap_labels(label_names):
+    """Group label names into lines that fit within LABEL_WIDTH (by visible chars)."""
+    lines, current, w = [], [], 0
+    for name in label_names:
+        badge_w = len(name) + 2   # " Name " visible width
+        gap = 1 if current else 0
+        if current and w + gap + badge_w > LABEL_WIDTH:
+            lines.append(current)
+            current, w = [name], badge_w
+        else:
+            current.append(name)
+            w += gap + badge_w
+    if current:
+        lines.append(current)
+    return lines or [[]]
+
+
 def print_table(data):
     if not data:
         print("No open PRs across workspace repos.")
         return
+    row = 0
     for entry in data:
-        print(f"\n\033[1m{entry['repo']}\033[0m")
+        repo_header = f"{ansi_bg(*REPO_BG)}{ansi_fg(*REPO_FG)}\033[1m  {entry['repo']}  {RESET}"
+        print(f"\n{repo_header}")
         print("─" * 72)
         for pr in entry["prs"]:
-            title = pr["title"][:48].ljust(48)
-            labels_str = " ".join(color_label(l) for l in pr["labels"]) if pr["labels"] else "—"
-            print(f"  {title}  {labels_str}  {pr['updated']}")
+            gray = ID_GRAYS[row % 2]
+            id_badge = f"{ansi_bg(*gray['bg'])}{ansi_fg(*gray['fg'])} {str(pr['number']).ljust(4)}{RESET}"
+            date = f"{UNDERLINE}{pr['updated']}{NO_UNDER}"
+
+            title_lines  = textwrap.wrap(pr["title"], TITLE_WIDTH) or [pr["title"]]
+            label_groups = wrap_labels(pr["labels"]) if pr["labels"] else [["—"]]
+            colored_groups = [
+                " ".join(color_label(l) for l in g) if g != ["—"] else "—"
+                for g in label_groups
+            ]
+
+            n = max(len(title_lines), len(colored_groups))
+            title_lines    += [""] * (n - len(title_lines))
+            colored_groups += [""] * (n - len(colored_groups))
+
+            for i, (t, lbl) in enumerate(zip(title_lines, colored_groups)):
+                if i == 0:
+                    print(f"  {id_badge}  {date}  {t.ljust(TITLE_WIDTH)}  {lbl}")
+                else:
+                    print(f"{' ' * TITLE_INDENT}{t.ljust(TITLE_WIDTH)}  {lbl}")
+            row += 1
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--json", action="store_true", help="Output JSON instead of colored table")
+    parser.add_argument("--json",   action="store_true", help="Output JSON instead of colored table")
+    parser.add_argument("--window", action="store_true", help="Open table in a new Ptyxis terminal window")
     args = parser.parse_args()
+
+    if args.window:
+        script = Path(__file__).resolve()
+        cmd = f"python3 {script}; echo; read -p 'Press Enter to close'"
+        subprocess.Popen(["ptyxis", "-T", "Open PRs", "--", "bash", "-c", cmd])
+        return
 
     repos = find_repos()
     data = collect_all(repos)

--- a/git-tools/scripts/list_prs.py
+++ b/git-tools/scripts/list_prs.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""
+Lists open PRs across all workspace repos, grouped by repo with colored label badges.
+
+Usage:
+    python3 list_prs.py           # ANSI colored table
+    python3 list_prs.py --json    # JSON output for programmatic use
+"""
+
+import argparse
+import json
+import subprocess
+from datetime import datetime
+from pathlib import Path
+
+WORKSPACE = Path.home() / "git-workspace/claude-workspace"
+
+LABEL_COLORS = {
+    "trivial":       {"bg": (46, 204, 113),  "fg": (0, 0, 0)},
+    "non-trivial":   {"bg": (241, 196, 15),  "fg": (0, 0, 0)},
+    "complex":       {"bg": (231, 76, 60),   "fg": (255, 255, 255)},
+    "integrated":    {"bg": (123, 36, 28),   "fg": (255, 255, 255)},
+    "system":        {"bg": (96, 125, 139),  "fg": (255, 255, 255)},
+    "documentation": {"bg": (0, 117, 202),   "fg": (255, 255, 255)},
+    "fix":           {"bg": (142, 68, 173),  "fg": (255, 255, 255)},
+    "enhancement":   {"bg": (162, 238, 239), "fg": (0, 0, 0)},
+    "duplicate":     {"bg": (207, 211, 215), "fg": (0, 0, 0)},
+    "as designed":   {"bg": (220, 220, 220), "fg": (0, 0, 0)},
+}
+
+RESET = "\033[0m"
+
+
+def ansi_bg(r, g, b):
+    return f"\033[48;2;{r};{g};{b}m"
+
+
+def ansi_fg(r, g, b):
+    return f"\033[38;2;{r};{g};{b}m"
+
+
+def color_label(name):
+    key = name.lower()
+    style = LABEL_COLORS.get(key)
+    if not style:
+        return f" {name} "
+    bg = ansi_bg(*style["bg"])
+    fg = ansi_fg(*style["fg"])
+    return f"{bg}{fg} {name} {RESET}"
+
+
+def fetch_prs(repo):
+    result = subprocess.run(
+        ["gh", "pr", "list", "--repo", repo, "--state", "open",
+         "--json", "number,title,labels,updatedAt"],
+        capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        return []
+    return json.loads(result.stdout)
+
+
+def find_repos():
+    return sorted([
+        d for d in WORKSPACE.iterdir()
+        if d.is_dir() and (d / ".git").exists()
+    ], key=lambda d: d.name)
+
+
+def collect_all(repos):
+    results = []
+    for repo_path in repos:
+        gh_repo_result = subprocess.run(
+            ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
+            capture_output=True, text=True, cwd=repo_path
+        )
+        if gh_repo_result.returncode != 0:
+            continue
+        gh_repo = gh_repo_result.stdout.strip()
+        prs = fetch_prs(gh_repo)
+        if not prs:
+            continue
+        prs.sort(key=lambda p: p["updatedAt"], reverse=True)
+        results.append({
+            "repo": repo_path.name,
+            "gh_repo": gh_repo,
+            "prs": [
+                {
+                    "number": pr["number"],
+                    "title": pr["title"],
+                    "labels": [l["name"] for l in pr["labels"]],
+                    "updated": pr["updatedAt"][:10],
+                }
+                for pr in prs
+            ],
+        })
+    return results
+
+
+def print_table(data):
+    if not data:
+        print("No open PRs across workspace repos.")
+        return
+    for entry in data:
+        print(f"\n\033[1m{entry['repo']}\033[0m")
+        print("─" * 72)
+        for pr in entry["prs"]:
+            title = pr["title"][:48].ljust(48)
+            labels_str = " ".join(color_label(l) for l in pr["labels"]) if pr["labels"] else "—"
+            print(f"  {title}  {labels_str}  {pr['updated']}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--json", action="store_true", help="Output JSON instead of colored table")
+    args = parser.parse_args()
+
+    repos = find_repos()
+    data = collect_all(repos)
+
+    if args.json:
+        print(json.dumps(data, indent=2))
+    else:
+        print_table(data)
+
+
+if __name__ == "__main__":
+    main()

--- a/git-tools/scripts/load_pr.py
+++ b/git-tools/scripts/load_pr.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+Loads a PR by number from any workspace repo.
+
+Searches all repos under ~/git-workspace/claude-workspace/ for the given PR
+number, resolves OWNER/REPO, then fetches gh pr view + gh pr diff in parallel.
+
+Usage:
+    python3 load_pr.py NUMBER
+    python3 load_pr.py REPO_FOLDER/NUMBER   # disambiguate when PR# exists in multiple repos
+"""
+
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+WORKSPACE = Path.home() / "git-workspace/claude-workspace"
+
+BOLD  = "\033[1m"
+RESET = "\033[0m"
+RED   = "\033[31m"
+
+
+def run(args, cwd=None):
+    result = subprocess.run(args, capture_output=True, text=True, cwd=cwd)
+    return result.stdout.strip(), result.returncode == 0
+
+
+def find_repos():
+    return sorted(
+        [d for d in WORKSPACE.iterdir() if d.is_dir() and (d / ".git").exists()],
+        key=lambda d: d.name,
+    )
+
+
+def resolve_gh_repo(repo_path):
+    out, ok = run(
+        ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
+        cwd=repo_path,
+    )
+    return out if ok else None
+
+
+def pr_exists(gh_repo, number):
+    _, ok = run(["gh", "pr", "view", str(number), "--repo", gh_repo])
+    return ok
+
+
+def fetch_view(gh_repo, number):
+    out, _ = run(["gh", "pr", "view", str(number), "--repo", gh_repo])
+    return out
+
+
+def fetch_diff(gh_repo, number):
+    out, _ = run(["gh", "pr", "diff", str(number), "--repo", gh_repo])
+    return out
+
+
+def main():
+    if len(sys.argv) != 2:
+        print(f"Usage: load_pr.py NUMBER  |  load_pr.py REPO/NUMBER")
+        sys.exit(1)
+
+    arg = sys.argv[1]
+    repo_hint = None
+
+    if "/" in arg:
+        parts = arg.rsplit("/", 1)
+        repo_hint, number_str = parts[0], parts[1]
+    else:
+        number_str = arg
+
+    try:
+        number = int(number_str)
+    except ValueError:
+        print(f"{RED}ERROR: '{number_str}' is not a valid PR number{RESET}")
+        sys.exit(1)
+
+    repos = find_repos()
+    if repo_hint:
+        repos = [r for r in repos if r.name == repo_hint]
+        if not repos:
+            print(f"{RED}ERROR: No repo folder named '{repo_hint}' in workspace{RESET}")
+            sys.exit(1)
+
+    # Find which repos have this PR number
+    matches = []
+    for repo_path in repos:
+        gh_repo = resolve_gh_repo(repo_path)
+        if gh_repo and pr_exists(gh_repo, number):
+            matches.append((repo_path, gh_repo))
+
+    if not matches:
+        print(f"{RED}ERROR: PR #{number} not found in any workspace repo{RESET}")
+        sys.exit(1)
+
+    if len(matches) > 1:
+        names = [f"  {r.name}/{number}" for r, _ in matches]
+        print(f"{RED}ERROR: PR #{number} exists in multiple repos — specify one:{RESET}")
+        print("\n".join(names))
+        sys.exit(1)
+
+    repo_path, gh_repo = matches[0]
+
+    print(f"\n{BOLD}Repo:{RESET}  {gh_repo}  (PR #{number})\n")
+
+    with ThreadPoolExecutor(max_workers=2) as ex:
+        view_f = ex.submit(fetch_view, gh_repo, number)
+        diff_f = ex.submit(fetch_diff, gh_repo, number)
+        view = view_f.result()
+        diff = diff_f.result()
+
+    print(f"{BOLD}{'─' * 72}{RESET}")
+    print(f"{BOLD}PR VIEW{RESET}")
+    print(f"{BOLD}{'─' * 72}{RESET}")
+    print(view)
+
+    print(f"\n{BOLD}{'─' * 72}{RESET}")
+    print(f"{BOLD}DIFF{RESET}")
+    print(f"{BOLD}{'─' * 72}{RESET}")
+    print(diff)
+
+
+if __name__ == "__main__":
+    main()

--- a/git-tools/scripts/pr.py
+++ b/git-tools/scripts/pr.py
@@ -92,9 +92,10 @@ def main():
         commit_message = meta["commit_message"]
         pr_title       = meta["pr_title"]
         pr_body        = meta["pr_body"]
+        labels         = meta.get("labels", [])
     except (json.JSONDecodeError, KeyError) as exc:
         print(f"ERROR: --meta is invalid — {exc}")
-        print(f"  Expected: {{\"branch_name\": \"...\", \"commit_message\": \"...\", \"pr_title\": \"...\", \"pr_body\": \"...\"}}")
+        print(f"  Expected: {{\"branch_name\": \"...\", \"commit_message\": \"...\", \"pr_title\": \"...\", \"pr_body\": \"...\", \"labels\": [...]}}")
         print(f"  Got: {args.meta}")
         sys.exit(1)
 
@@ -174,6 +175,12 @@ def main():
         cwd=repo,
     )
     print(f"\nPR: {pr_url}")
+
+    # Apply labels
+    if labels:
+        pr_number = pr_url.rstrip("/").split("/")[-1]
+        run(["gh", "pr", "edit", pr_number, "--repo", gh_repo, "--add-label", ",".join(labels)], cwd=repo)
+        print(f"Labels: {', '.join(labels)}")
 
     # PR list
     prs_raw = run(


### PR DESCRIPTION
Extends the PR script to accept and apply GitHub labels from the metadata JSON passed by Claude. Adds a utility to bootstrap the standard label set on any new repo.