### PR TITLE
Add invocation guards to pr, todo, and record skills

### DIFF
--- a/New Boot/new-machine-setup.md
+++ b/New Boot/new-machine-setup.md
@@ -8,7 +8,12 @@
 
 ## 1. Prerequisites
 
-Ensure your user has sudo access and the following are available:
+Update all system packages before installing anything:
+```bash
+sudo dnf update --refresh
+```
+
+Then confirm your user has sudo access and the following are available:
 ```bash
 sudo -v           # confirm sudo works
 curl --version

--- a/claude/skills/pr/SKILL.md
+++ b/claude/skills/pr/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: pr
+description: Create a pull request for the relevant git repo under ~/git-workspace/claude-workspace/. Claude generates branch name, commit message, and PR body in-conversation, then passes them to a Python script that handles all git mechanics. Shows branch transitions in blue.
+---
+
+Create a pull request for the relevant repository.
+
+## Pre-flight — Confirm explicit user request
+
+**Before doing anything**, verify the user explicitly asked for a PR in their most recent message.
+
+Accepted triggers: the user typed `/pr`, `pr`, "open a PR", "create a PR", "make a PR", or a clear equivalent.
+
+If Claude is running this as a proactive follow-on step, an end-of-task suggestion, or anything other than a direct user request — **stop immediately and do not proceed**. Offer to create the PR instead:
+
+> "Want me to open a PR for this?"
+
+Only continue to Step 1 if the user's request is unambiguous.
+
+---
+
+## Step 1 — Identify the repo and gather context
+
+From conversation context, determine which single repo under `/home/ClaudeSpace/git-workspace/claude-workspace/` has the changes. Use that path as REPO.
+
+Run in one command to get the diff context:
+```bash
+git -C REPO fetch origin && git -C REPO diff origin/main --stat && git -C REPO status --short && git -C REPO log origin/main..HEAD --oneline
+```
+
+## Step 2 — Generate PR metadata
+
+Based on the diff output, produce a JSON object with exactly these fields:
+- `branch_name`: kebab-case, max 3 words, describes what changed
+- `commit_message`: imperative mood, max 72 chars
+- `pr_title`: max 70 chars, same intent as commit_message
+- `pr_body`: plain prose, max 4 sentences, no bullet points. Describe the goal the change achieves — never list file paths, enumerate individual scripts, or echo the user's request. Avoid self-evident framing like "Replaces X with Y" or "Updates X to include Y" — lead with the substance. File locations and what changed are visible in the diff; the body should convey intent and why.
+- `labels`: array of label strings to apply. Choose from the available labels below — multiple can apply.
+
+### Closing issues via PR
+
+If this PR resolves a GitHub issue **and** no further testing, verification, or follow-up is required after merge, prepend `Closes #N` as the very first line of `pr_body`, followed by a blank line:
+
+```
+Closes #42
+
+The rest of the body here...
+```
+
+GitHub will auto-close the issue when the PR is merged. Do **not** add `Closes #N` if:
+- The issue requires manual verification after the change lands
+- The PR is one step toward resolving the issue but more work remains
+- There is any ambiguity about whether the issue is fully addressed
+
+When a `Closes` clause is present, issues must **not** be closed via `gh issue close` — the merge handles it. Only use `gh issue close` directly for issues with no associated PR.
+
+**Available labels:**
+- `Trivial` — small, low-risk change
+- `Non-Trivial` — needs a scan through, largely harmless
+- `Complex` — requires focused review
+- `Integrated` — touches core structure, likely to break without human review
+- `System` — changes to OS, containerization, or automation
+- `Documentation` — includes documentation updates
+- `Fix` — bug fix or correction
+- `Enhancement` — new feature or capability
+
+## Step 3 — Run the script
+
+Pass the JSON as a single-quoted string to `--meta`:
+
+```bash
+python3 /home/ClaudeSpace/git-workspace/claude-workspace/Claude-Project-Tooling/git-tools/scripts/pr.py \
+  --repo REPO \
+  --meta 'JSON_HERE'
+```
+
+The script handles everything from here: sync state check, stash-only-if-needed, branch creation, commit, push, and PR creation.
+
+## Step 4 — Interpret output
+
+On success the script prints the PR URL and a numbered list of open PRs with the new one in blue.
+
+Errors are labelled — if any appear:
+- `ERROR: command failed (exit N)` → read CMD/STDOUT/STDERR and fix the underlying issue
+- `ERROR: --meta is invalid` → fix the JSON shape and rerun

--- a/claude/skills/pr/SKILL.md
+++ b/claude/skills/pr/SKILL.md
@@ -37,17 +37,34 @@ Based on the diff output, produce a JSON object with exactly these fields:
 - `pr_body`: plain prose, max 4 sentences, no bullet points. Describe the goal the change achieves — never list file paths, enumerate individual scripts, or echo the user's request. Avoid self-evident framing like "Replaces X with Y" or "Updates X to include Y" — lead with the substance. File locations and what changed are visible in the diff; the body should convey intent and why.
 - `labels`: array of label strings to apply. Choose from the available labels below — multiple can apply.
 
-### Closing issues via PR
+### Linking issues in PR body
 
-If this PR resolves a GitHub issue **and** no further testing, verification, or follow-up is required after merge, prepend `Closes #N` as the very first line of `pr_body`, followed by a blank line:
+If this PR has an associated GitHub issue, the issue reference must be the very first line of `pr_body`, followed by a `---` divider and a blank line before the prose:
+
+- Use `Closes #N` when the merge fully resolves the issue with no further verification or follow-up required — GitHub auto-closes it on merge.
+- Use `#N` (bare reference) when the PR relates to an issue but does not fully close it.
 
 ```
 Closes #42
 
+---
+
 The rest of the body here...
 ```
 
-GitHub will auto-close the issue when the PR is merged. Do **not** add `Closes #N` if:
+Multiple issues stack on separate lines before the divider:
+
+```
+Closes #18
+Closes #19
+#20
+
+---
+
+The rest of the body here...
+```
+
+Do **not** use `Closes #N` if:
 - The issue requires manual verification after the change lands
 - The PR is one step toward resolving the issue but more work remains
 - There is any ambiguity about whether the issue is fully addressed

--- a/claude/skills/record/SKILL.md
+++ b/claude/skills/record/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: record
+description: Record the current Claude session to RS-Agent-Planning/Claude Sessions. Must only run when explicitly invoked by the user. Never invoke proactively or as a follow-on step. The "auto" argument is reserved for Stop hook automation only.
+---
+
+Record the current Claude session to `~/git-workspace/claude-workspace/RS-Agent-Planning/Claude Sessions/`.
+
+## Pre-flight — Confirm explicit user request
+
+**Before doing anything**, verify one of the following is true:
+
+1. The user explicitly invoked this skill in their last message (e.g. typed `record`, `/record`, or a clear equivalent).
+2. The skill was called with the `auto` argument — this is the Stop hook path and is always permitted.
+
+If Claude is running this as a proactive follow-on step or inferred end-of-session cleanup — **stop immediately and do not proceed**. The user must ask for it explicitly.
+
+---
+
+## Pre-flight — Check for Claude-Project-Tooling changes
+
+Before writing the session log, run:
+```bash
+git -C ~/git-workspace/claude-workspace/Claude-Project-Tooling status --short
+```
+
+If there are **any uncommitted or unstaged changes** in that repo, stop and tell the user:
+
+> Claude-Project-Tooling has uncommitted changes. Run `/pr` to open a pull request for those changes before recording — otherwise they won't be pushed (push_sessions.py only pushes RS-Agent-Planning session logs).
+
+Do **not** proceed with the session log until the user confirms how to handle it (either they run `/pr` or they confirm the changes can be discarded).
+
+---
+
+## Step 1 — Determine action
+
+```bash
+python3 /home/ClaudeSpace/git-workspace/claude-workspace/Claude-Project-Tooling/claude/recording/session_detect.py [auto]
+```
+
+Pass `auto` as the argument if the skill was invoked with `auto`. The script outputs JSON:
+`{"action": "append"|"new"|"ask", "file": "/path/to/latest.md", "latest_date": "YYYY-MM-DD", "today": "YYYY-MM-DD"}`
+
+**Branch logic:**
+- `new` → go to **CREATE NEW LOG**
+- `append` → go to **APPEND**
+- `ask` → prompt the user:
+  ```
+  The last session log is from [latest_date]. Create a new log for today?
+  1) Yes — create new log
+  2) No — append to existing
+  ```
+  → 1 → **CREATE NEW LOG**, 2 → **APPEND**
+
+---
+
+## CREATE NEW LOG
+
+1. Run `date +"%Y-%m-%d %H:%M"` for the timestamp.
+2. Write a new file at:
+   `~/git-workspace/claude-workspace/RS-Agent-Planning/Claude Sessions/YYYY-MM-DD-HH:MM.md`
+   with these sections:
+   - `# Claude Session — YYYY-MM-DD HH:MM`
+   - `## Summary` — first entry using the format described below
+   - `## Terminal Commands — YYYY-MM-DD HH:MM` — all bash commands in a single fenced code block with inline comments
+   - `## Files Created — YYYY-MM-DD HH:MM` — markdown table of files created or modified (path + description)
+   - `## Notes` — important reminders or follow-up items
+3. Only if apps were installed or updated this session: update `~/git-workspace/claude-workspace/Claude-Project-Tooling/dev-workspace-versions.md` (run version commands to get accurate versions; add/update rows, never remove existing entries).
+4. Go to **TOKEN USAGE**, then **PUSH**.
+
+---
+
+## APPEND
+
+1. Read the file path returned by session_detect.py.
+2. Insert a new summary entry into the existing `## Summary` section (after the last `### ` entry already there).
+3. Append a new `## Terminal Commands — YYYY-MM-DD HH:MM` section and a new `## Files Created — YYYY-MM-DD HH:MM` section at the bottom of the file covering everything done since the last record.
+4. Only if apps were installed or updated this session: update `~/git-workspace/claude-workspace/Claude-Project-Tooling/dev-workspace-versions.md` same as above.
+5. Go to **TOKEN USAGE**, then **PUSH**.
+
+---
+
+## Summary format
+
+The `## Summary` section contains one `### YYYY-MM-DD HH:MM` subsection per record invocation. Each subsection uses bold topic labels followed by a concise description on the same line. Group related work under the same label. Example:
+
+```markdown
+## Summary
+
+### 2026-04-25 15:38
+**Skills** — created init skill, merged sess-add/append/push-session into record, deleted legacy skills
+**Config** — added claude alias to .bashrc, set bypassPermissions in settings.json, removed Stop hook
+
+### 2026-04-25 17:45
+**PR skill** — reduced from 8 to 5 steps, chained commands, removed redundant fetch+merge
+**Permissions** — fixed dangerouslySkipPermissions schema, added explicit allow rules for git/gh/for/python3/rm
+**Record skill** — combined Step 1 commands, conditional dev-workspace-versions update, chained PUSH
+```
+
+---
+
+## TOKEN USAGE
+
+Run:
+```bash
+python3 /home/ClaudeSpace/git-workspace/claude-workspace/Claude-Project-Tooling/claude/recording/token_usage.py
+```
+
+Replace the session table rows and totals in
+`~/git-workspace/claude-workspace/RS-Agent-Planning/Claude Sessions/Usage/token-usage.md`
+and update the "Last updated" date. The script outputs one `| row |` per session file followed by a `TOTALS` line.
+
+---
+
+## PUSH
+
+```bash
+python3 /home/ClaudeSpace/git-workspace/claude-workspace/Claude-Project-Tooling/git-tools/scripts/push_sessions.py --message "MESSAGE"
+```
+
+Use a short descriptive commit message (e.g. "Update Claude Sessions and token usage"). The script only stages and pushes files under `Claude Sessions/` in RS-Agent-Planning. Claude-Project-Tooling is never touched — script changes there must go through `/pr`.

--- a/claude/skills/todo/SKILL.md
+++ b/claude/skills/todo/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: todo
+description: Create a GitHub issue from free-form text. Prompts the user to choose a repo (Claude-Project-Tooling or RS-Agent-Planning), then generates a short title, description, and appropriate labels before opening the issue.
+---
+
+Create a GitHub issue from the text passed as the skill argument.
+
+## Step 1 — Read the input
+
+The skill argument is the raw text the user typed after /todo. Use it to understand the intent.
+
+## Step 2 — Suggest a repo
+
+Infer which repo the issue belongs to based on the text:
+- If it relates to tooling, skills, setup, Claude config, or workspace infrastructure → suggest **Claude-Project-Tooling**
+- If it relates to planning, agents, architecture, or project work → suggest **RS-Agent-Planning**
+- If unclear → suggest **Claude-Project-Tooling** as default
+
+Run the matching bash command to display a colored menu. The suggested repo is highlighted in bold green.
+
+If **Claude-Project-Tooling** is suggested:
+```bash
+printf '\nWhich repo should this issue go to?\n\n'
+printf '  1) \033[1;32mClaude-Project-Tooling\033[0m  \033[32m← suggested\033[0m\n'
+printf '  2) RS-Agent-Planning\n\n'
+```
+
+If **RS-Agent-Planning** is suggested:
+```bash
+printf '\nWhich repo should this issue go to?\n\n'
+printf '  1) Claude-Project-Tooling\n'
+printf '  2) \033[1;32mRS-Agent-Planning\033[0m  \033[32m← suggested\033[0m\n\n'
+```
+
+After running the printf command, output **only** a short prompt — do not re-echo the menu in text. The Bash output is already visible. Example follow-up: `Which? (1 or 2)`
+
+Wait for the user to respond with 1 or 2. Use their choice as TARGETREPO.
+
+## Step 3 — Generate title, description, and labels
+
+From the input text, derive:
+- **Title**: short, imperative, max 6 words (e.g. "Add retry logic to pr skill", "Fix token usage parsing")
+- **Description**: 1-3 sentences expanding on the intent. Be concise. No bullet lists. Do not speculate on root cause or solutions — describe only the observed problem or desired outcome.
+- **Labels**: pick all that apply from the standard vocabulary below. Most issues take 1-2 labels.
+
+### Label vocabulary
+
+| Label | When to use |
+|-------|-------------|
+| `Code` | Writing new feature code |
+| `Defect` | Fixing broken or incorrect behavior |
+| `Discovery` | Investigation or research needed before work can start |
+| `Inquiry` | Open design question that must be resolved first |
+| `DevOps` | Infrastructure, deployment, CI/CD, or automation work |
+| `Service: MCP` | Changes specific to the MCP server |
+| `Epic` | Do not use — reserved for git-plan |
+
+## Step 4 — Create the issue
+
+Run:
+
+```bash
+python3 Claude-Project-Tooling/git-tools/scripts/issue_utils.py \
+  --repo AndresI19/TARGETREPO \
+  --title "TITLE" \
+  --body "DESCRIPTION" \
+  --label LABEL1 --label LABEL2
+```
+
+Omit `--label` flags if no labels apply. Print the issue URL when done.


### PR DESCRIPTION
Fixes three behavioral issues where Claude invoked skills without explicit user instruction. The /pr skill now requires an unambiguous user trigger before running, the /todo skill suppresses menu re-echo after the Bash printf call, and the /record skill guards against autonomous end-of-session invocation. Skill source files are added to claude/skills/ for version tracking.