### PR TITLE
Add test suite, fix shell injection, and document skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,158 @@ Shared scripts, configuration, and tooling for the Claude Code workspace. Used b
 
 ## Skills
 
-Claude skills that use this tooling live in `~/.claude/skills/` and are not checked in here. The scripts in this repo are the mechanical layer those skills delegate to.
+Skills are Claude Code slash commands that orchestrate the tooling in this repo. They live in two places:
+
+- **`claude/skills/`** — tracked copies checked into this repo (source of truth for history and PRs)
+- **`~/.claude/skills/`** — live copies loaded by Claude Code at runtime
+
+Project-level commands (available only inside `claude-workspace/`) live in `.claude/commands/` of the workspace root.
+
+### Summary
+
+| Skill | Scope | Description |
+|-------|-------|-------------|
+| `/pr` | user | Generate PR metadata in-conversation, then run `pr.py` to branch, commit, push, and open the PR |
+| `/record` | user | Write or append to the session log in RS-Agent-Planning, update token usage, and push |
+| `/review` | user | List open PRs in a Ptyxis window, load a selected PR, and produce a structured code review |
+| `/todo` | user | Create a GitHub issue from free-form text with auto-generated title, body, and labels |
+| `/git-plan` | project | Plan a new GitHub project top-down (Epics → Issues), iterate until approved, then create it |
+| `/new-task` | project | Pick a Ready issue from the project board and move it to In Progress |
+| `/work-flow` | project | Drive the full project loop — work all Ready issues, then trigger `/git-plan` when done |
+
+---
+
+### `/pr`
+
+Create a pull request for any repo in the workspace.
+
+```
+Claude (in-conversation)
+  └─ generates JSON: { branch_name, commit_message, pr_title, pr_body, labels }
+       └─ scripts/pr.py --repo PATH --meta '{...}'
+            └─ git, gh CLI  (stash · branch · commit · push · gh pr create)
+```
+
+---
+
+### `/record`
+
+Append or create a session log, update token totals, and push.
+
+```
+claude/recording/session_detect.py   ← determines: new | append | ask
+  │
+  ├─ Claude writes/appends session log file directly
+  │
+  ├─ claude/recording/token_usage.py  ← reads ~/.claude/**/*.jsonl, outputs markdown rows
+  │
+  └─ scripts/push_sessions.py         ← stages Claude Sessions/, commits, pushes to origin/main
+       └─ git CLI
+```
+
+---
+
+### `/review`
+
+List open PRs, load the selected one, and review it.
+
+```
+interface/list_prs.py --window
+  └─ scripts/list_prs.py :: show()
+       └─ lib/prs.py        ← collects PRs across all workspace repos
+            └─ lib/display.py  ← ANSI color badges
+
+scripts/load_pr.py NUMBER
+  └─ lib/prs.py :: get_pr_view() + get_pr_diff()
+       └─ lib/github_client.py  ← REST API (gh auth token)
+
+Claude  ← synthesises review from loaded diff + metadata
+```
+
+---
+
+### `/todo`
+
+Create a GitHub issue from typed text.
+
+```
+Claude (in-conversation)
+  └─ generates: title, body, labels
+       └─ interface/create_issue.py --repo ... --title ... --body ... --label ...
+            └─ scripts/create_issue.py :: create()
+                 └─ lib/github_client.py :: get_or_create_issue()  ← REST POST /repos/.../issues
+```
+
+---
+
+### `/git-plan`
+
+Plan and execute a new GitHub project.
+
+```
+── Pre-flight ──────────────────────────────────────────────────────
+interface/advance_ready.py
+  └─ scripts/project_advance.py :: run()
+       └─ lib/project.py :: advance_ready()
+            └─ lib/github_client.py  ← GraphQL (project field mutations)
+
+interface/loop_state.py
+  └─ scripts/project_state.py :: loop_state()
+       └─ lib/project.py :: items_by_status()
+
+── Phase 1 (plan) ──────────────────────────────────────────────────
+Claude reads RS-Agent-Planning/Planning/  ← architecture, tasks, overview
+Claude writes plan to plan file; iterates with user
+
+── Phase 2 (execute) ───────────────────────────────────────────────
+scripts/git-plan.py --meta '{...}'
+  └─ lib/github_client.py  ← GraphQL (create project · epics · issues · link)
+```
+
+---
+
+### `/new-task`
+
+Pick a ready task and start it.
+
+```
+scripts/project_items.py --status Ready --json
+  └─ lib/project.py :: items_by_status()
+       └─ lib/github_client.py  ← GraphQL
+
+gh issue view NUMBER  ← direct CLI
+
+scripts/project_items.py --set-status ITEM_ID "In Progress"
+  └─ lib/project.py :: set_item_status_by_name()
+       └─ lib/github_client.py  ← GraphQL (project field mutation)
+```
+
+---
+
+### `/work-flow`
+
+Drive the full project loop autonomously.
+
+```
+── Pre-flight ──────────────────────────────────────────────────────
+interface/advance_ready.py  (same as /git-plan pre-flight above)
+
+── Per-issue loop ──────────────────────────────────────────────────
+interface/ready_items.py
+  └─ scripts/project_items.py :: list_items(status="Ready")
+
+gh issue view NUMBER  ← direct CLI
+
+interface/set_status.py ITEM_ID "In Progress"
+  └─ scripts/project_items.py :: update_status()
+
+Claude  ← does the work based on issue labels
+
+interface/advance_ready.py  ← promotes any newly unblocked items
+
+── Transition ──────────────────────────────────────────────────────
+interface/status_items.py STATUS   ← called for: In Progress · Todo · Backlog
+  └─ scripts/project_items.py :: list_items(status=STATUS)
+
+/git-plan  ← invoked when all queues are empty
+```

--- a/claude/skills/pr/SKILL.md
+++ b/claude/skills/pr/SKILL.md
@@ -52,22 +52,9 @@ Closes #42
 The rest of the body here...
 ```
 
-Multiple issues stack on separate lines before the divider:
+Multiple issues stack on separate lines before the divider — mix `Closes #N` and bare `#N` as appropriate.
 
-```
-Closes #18
-Closes #19
-#20
-
----
-
-The rest of the body here...
-```
-
-Do **not** use `Closes #N` if:
-- The issue requires manual verification after the change lands
-- The PR is one step toward resolving the issue but more work remains
-- There is any ambiguity about whether the issue is fully addressed
+Do **not** use `Closes #N` unless the merge fully resolves the issue with no further verification or follow-up remaining.
 
 When a `Closes` clause is present, issues must **not** be closed via `gh issue close` — the merge handles it. Only use `gh issue close` directly for issues with no associated PR.
 

--- a/claude/skills/record/SKILL.md
+++ b/claude/skills/record/SKILL.md
@@ -65,7 +65,7 @@ Pass `auto` as the argument if the skill was invoked with `auto`. The script out
    - `## Files Created — YYYY-MM-DD HH:MM` — markdown table of files created or modified (path + description)
    - `## Notes` — important reminders or follow-up items
 3. Only if apps were installed or updated this session: update `~/git-workspace/claude-workspace/Claude-Project-Tooling/dev-workspace-versions.md` (run version commands to get accurate versions; add/update rows, never remove existing entries).
-4. Go to **TOKEN USAGE**, then **PUSH**.
+4. Go to **FINALIZE**.
 
 ---
 
@@ -75,7 +75,7 @@ Pass `auto` as the argument if the skill was invoked with `auto`. The script out
 2. Insert a new summary entry into the existing `## Summary` section (after the last `### ` entry already there).
 3. Append a new `## Terminal Commands — YYYY-MM-DD HH:MM` section and a new `## Files Created — YYYY-MM-DD HH:MM` section at the bottom of the file covering everything done since the last record.
 4. Only if apps were installed or updated this session: update `~/git-workspace/claude-workspace/Claude-Project-Tooling/dev-workspace-versions.md` same as above.
-5. Go to **TOKEN USAGE**, then **PUSH**.
+5. Go to **FINALIZE**.
 
 ---
 
@@ -89,18 +89,14 @@ The `## Summary` section contains one `### YYYY-MM-DD HH:MM` subsection per reco
 ### 2026-04-25 15:38
 **Skills** — created init skill, merged sess-add/append/push-session into record, deleted legacy skills
 **Config** — added claude alias to .bashrc, set bypassPermissions in settings.json, removed Stop hook
-
-### 2026-04-25 17:45
-**PR skill** — reduced from 8 to 5 steps, chained commands, removed redundant fetch+merge
-**Permissions** — fixed dangerouslySkipPermissions schema, added explicit allow rules for git/gh/for/python3/rm
-**Record skill** — combined Step 1 commands, conditional dev-workspace-versions update, chained PUSH
 ```
 
 ---
 
-## TOKEN USAGE
+## FINALIZE
 
-Run:
+Run token usage, then push:
+
 ```bash
 python3 /home/ClaudeSpace/git-workspace/claude-workspace/Claude-Project-Tooling/claude/recording/token_usage.py
 ```
@@ -108,10 +104,6 @@ python3 /home/ClaudeSpace/git-workspace/claude-workspace/Claude-Project-Tooling/
 Replace the session table rows and totals in
 `~/git-workspace/claude-workspace/RS-Agent-Planning/Claude Sessions/Usage/token-usage.md`
 and update the "Last updated" date. The script outputs one `| row |` per session file followed by a `TOTALS` line.
-
----
-
-## PUSH
 
 ```bash
 python3 /home/ClaudeSpace/git-workspace/claude-workspace/Claude-Project-Tooling/git-tools/scripts/push_sessions.py --message "MESSAGE"

--- a/claude/skills/todo/SKILL.md
+++ b/claude/skills/todo/SKILL.md
@@ -60,7 +60,7 @@ From the input text, derive:
 Run:
 
 ```bash
-python3 Claude-Project-Tooling/git-tools/scripts/issue_utils.py \
+python3 Claude-Project-Tooling/git-tools/interface/create_issue.py \
   --repo AndresI19/TARGETREPO \
   --title "TITLE" \
   --body "DESCRIPTION" \

--- a/git-tools/scripts/pr.py
+++ b/git-tools/scripts/pr.py
@@ -55,7 +55,7 @@ def run_silent(args, cwd=None):
 # ---------------------------------------------------------------------------
 
 def find_base_branch(repo):
-    remote_branches, _ = run_silent("git branch -r", cwd=repo)
+    remote_branches, _ = run_silent(["git", "branch", "-r"], cwd=repo)
     if "origin/main" in remote_branches:
         return "main"
     if "origin/develop" in remote_branches:
@@ -64,13 +64,13 @@ def find_base_branch(repo):
 
 
 def is_behind_origin(repo, base):
-    status = run("git status -uno", cwd=repo)
+    status = run(["git", "status", "-uno"], cwd=repo)
     return "behind" in status
 
 
 def has_changes(repo, base):
-    diff_stat = run(f"git diff origin/{base} --stat", cwd=repo)
-    status = run("git status --short", cwd=repo)
+    diff_stat = run(["git", "diff", f"origin/{base}", "--stat"], cwd=repo)
+    status = run(["git", "status", "--short"], cwd=repo)
     return bool(diff_stat or status), diff_stat, status
 
 
@@ -109,7 +109,7 @@ def main():
 
     # Fetch + base branch
     print("Fetching from origin...")
-    run("git fetch origin", cwd=repo)
+    run(["git", "fetch", "origin"], cwd=repo)
 
     base = find_base_branch(repo)
     if not base:
@@ -124,7 +124,7 @@ def main():
         sys.exit(0)
 
     # Current branch + sync state
-    current_branch = run("git branch --show-current", cwd=repo)
+    current_branch = run(["git", "branch", "--show-current"], cwd=repo)
     already_on_base = current_branch == base
     behind = is_behind_origin(repo, base)
 
@@ -138,17 +138,17 @@ def main():
         print(f"Stashing ({reason})...")
         run(["git", "stash", "push", "-u", "-m", "pr-script-stash"], cwd=repo)
         stashed = True
-        run(f"git checkout {base}", cwd=repo)
-        run(f"git pull origin {base}", cwd=repo)
+        run(["git", "checkout", base], cwd=repo)
+        run(["git", "pull", "origin", base], cwd=repo)
     else:
         print("Already on base and up to date — skipping stash/pull.")
 
     # Create branch
-    run_silent(f"git branch -D {branch_name}", cwd=repo)  # delete stale, ignore failure
-    run(f"git checkout -b {branch_name}", cwd=repo)
+    run_silent(["git", "branch", "-D", branch_name], cwd=repo)  # delete stale, ignore failure
+    run(["git", "checkout", "-b", branch_name], cwd=repo)
 
     if stashed:
-        run("git stash pop", cwd=repo)
+        run(["git", "stash", "pop"], cwd=repo)
 
     transition = (
         f"{current_branch} → {base} → {branch_name}"
@@ -158,13 +158,13 @@ def main():
     print(f"{BLUE}→ {Path(repo).name}: {transition}{RESET}")
 
     # Commit + push
-    run("git add -A", cwd=repo)
+    run(["git", "add", "-A"], cwd=repo)
     run(["git", "commit", "-m", commit_message, "-m", CO_AUTHOR], cwd=repo)
-    run(f"git push -u origin {branch_name}", cwd=repo)
+    run(["git", "push", "-u", "origin", branch_name], cwd=repo)
     print(f"{BLUE}→ Publishing {branch_name} to origin{RESET}")
 
     # PR
-    gh_repo = run("gh repo view --json nameWithOwner -q .nameWithOwner", cwd=repo)
+    gh_repo = run(["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"], cwd=repo)
     pr_url = run(
         ["gh", "pr", "create",
          "--repo", gh_repo,
@@ -184,12 +184,12 @@ def main():
 
     # PR list
     prs_raw = run(
-        f"gh pr list --repo {gh_repo} --state open "
-        "--json number,title,headRefName,createdAt,url",
+        ["gh", "pr", "list", "--repo", gh_repo, "--state", "open",
+         "--json", "number,title,headRefName,createdAt,url"],
         cwd=repo,
     )
     prs = sorted(json.loads(prs_raw), key=lambda p: p["createdAt"])[:3]
-    total = run(f"gh pr list --repo {gh_repo} --state open --json number", cwd=repo)
+    total = run(["gh", "pr", "list", "--repo", gh_repo, "--state", "open", "--json", "number"], cwd=repo)
     total_count = len(json.loads(total))
     print(f"\nOpen PRs ({total_count} total):")
     for i, pr in enumerate(prs, 1):

--- a/git-tools/tests/conftest.py
+++ b/git-tools/tests/conftest.py
@@ -1,0 +1,48 @@
+"""Shared test configuration — adds lib/ and scripts/ to sys.path."""
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+# lib/ must precede scripts/ so lib/github_client.py wins over the thin CLI wrapper in scripts/
+sys.path.insert(0, str(ROOT / "scripts"))
+sys.path.insert(0, str(ROOT / "lib"))
+
+
+# ── Shared project-data fixtures ──────────────────────────────────────────────
+
+def make_item(number, title, status, state="OPEN", labels=None):
+    """Build a minimal project item dict matching the GitHub GraphQL shape."""
+    return {
+        "id": f"PVTI_{number}",
+        "fieldValues": {
+            "nodes": [{"name": status, "field": {"name": "Status"}}]
+        },
+        "content": {
+            "number": number,
+            "title":  title,
+            "state":  state,
+            "url":    f"https://github.com/test/repo/issues/{number}",
+            "labels": {"nodes": [{"name": l} for l in (labels or [])]},
+        },
+    }
+
+
+def make_project_data(items, status_options=None):
+    """Build a minimal project_data dict for testing."""
+    if status_options is None:
+        status_options = [
+            {"id": "opt_todo",    "name": "Todo"},
+            {"id": "opt_ready",   "name": "Ready"},
+            {"id": "opt_backlog", "name": "Backlog"},
+            {"id": "opt_inprog",  "name": "In Progress"},
+            {"id": "opt_verify",  "name": "Verify"},
+        ]
+    return {
+        "id": "PVT_test",
+        "fields": {
+            "nodes": [
+                {"id": "field_status", "name": "Status", "options": status_options}
+            ]
+        },
+        "items": {"nodes": items},
+    }

--- a/git-tools/tests/test_display.py
+++ b/git-tools/tests/test_display.py
@@ -1,0 +1,101 @@
+"""Tests for lib/display.py — pure ANSI rendering helpers."""
+import pytest
+from display import ansi_bg, ansi_fg, visible_len, ljust_visible, color_label
+
+RESET = "\033[0m"
+
+COLOR_MAP = {
+    "code":   {"bg": (22, 101, 52),  "fg": (255, 255, 255)},
+    "defect": {"bg": (211, 47,  47), "fg": (255, 255, 255)},
+}
+
+
+class TestAnsiHelpers:
+    def test_ansi_bg_format(self):
+        assert ansi_bg(22, 101, 52) == "\033[48;2;22;101;52m"
+
+    def test_ansi_fg_format(self):
+        assert ansi_fg(255, 255, 255) == "\033[38;2;255;255;255m"
+
+    def test_ansi_bg_zero(self):
+        assert ansi_bg(0, 0, 0) == "\033[48;2;0;0;0m"
+
+    def test_ansi_fg_zero(self):
+        assert ansi_fg(0, 0, 0) == "\033[38;2;0;0;0m"
+
+
+class TestVisibleLen:
+    def test_plain_string(self):
+        assert visible_len("hello") == 5
+
+    def test_empty_string(self):
+        assert visible_len("") == 0
+
+    def test_strips_simple_ansi(self):
+        assert visible_len("\033[32mhello\033[0m") == 5
+
+    def test_strips_rgb_bg_ansi(self):
+        assert visible_len("\033[48;2;22;101;52mhello\033[0m") == 5
+
+    def test_strips_multiple_codes(self):
+        assert visible_len("\033[1m\033[34mhello world\033[0m") == 11
+
+    def test_unicode_counted_correctly(self):
+        assert visible_len("café") == 4
+
+    def test_only_ansi_gives_zero(self):
+        assert visible_len("\033[32m\033[0m") == 0
+
+
+class TestLjustVisible:
+    def test_plain_padding(self):
+        assert ljust_visible("hi", 5) == "hi   "
+
+    def test_colored_string_padded_by_visible_length(self):
+        colored = "\033[32mhi\033[0m"  # visible length 2
+        result = ljust_visible(colored, 5)
+        assert result == colored + "   "
+
+    def test_exact_width_no_padding(self):
+        assert ljust_visible("hello", 5) == "hello"
+
+    def test_wider_than_width_no_truncation(self):
+        # Overflow — no truncation, just no padding
+        result = ljust_visible("toolong", 4)
+        assert result == "toolong"
+
+    def test_zero_width(self):
+        assert ljust_visible("x", 0) == "x"
+
+
+class TestColorLabel:
+    def test_known_label_contains_bg_escape(self):
+        result = color_label("code", COLOR_MAP)
+        assert "\033[48;2;" in result
+
+    def test_known_label_contains_fg_escape(self):
+        result = color_label("code", COLOR_MAP)
+        assert "\033[38;2;" in result
+
+    def test_known_label_ends_with_reset(self):
+        assert color_label("code", COLOR_MAP).endswith(RESET)
+
+    def test_known_label_contains_name(self):
+        assert "code" in color_label("code", COLOR_MAP)
+
+    def test_unknown_label_returns_plain_padded(self):
+        result = color_label("unknown", COLOR_MAP)
+        assert result == " unknown "
+        assert "\033[" not in result
+
+    def test_case_insensitive_lookup_applies_color(self):
+        # Lookup is case-insensitive (both get colored), but display preserves original case
+        assert "\033[48;2;" in color_label("Code", COLOR_MAP)
+        assert "\033[48;2;" in color_label("CODE", COLOR_MAP)
+
+    def test_case_insensitive_preserves_display_text(self):
+        assert "Code" in color_label("Code", COLOR_MAP)
+        assert "CODE" in color_label("CODE", COLOR_MAP)
+
+    def test_empty_color_map_always_plain(self):
+        assert color_label("code", {}) == " code "

--- a/git-tools/tests/test_github_client.py
+++ b/git-tools/tests/test_github_client.py
@@ -1,0 +1,181 @@
+"""Tests for lib/github_client.py (load_config, error checkers) and
+lib/prs.py (get_repo_full_name URL parsing)."""
+import json
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import github_client
+from github_client import load_config, _check_http, _check_graphql_errors
+from prs import get_repo_full_name
+
+
+# ── load_config ────────────────────────────────────────────────────────────────
+
+class TestLoadConfig:
+    def test_returns_defaults_when_file_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(github_client, "_CONFIG_PATH", tmp_path / "missing.json")
+        result = load_config()
+        assert result["owner"] == "AndresI19"
+        assert result["project_number"] == 5
+        assert "repo" in result
+
+    def test_file_overrides_defaults(self, tmp_path, monkeypatch):
+        cfg = tmp_path / ".config"
+        cfg.write_text(json.dumps({"owner": "OtherUser", "project_number": 99}))
+        monkeypatch.setattr(github_client, "_CONFIG_PATH", cfg)
+        result = load_config()
+        assert result["owner"] == "OtherUser"
+        assert result["project_number"] == 99
+
+    def test_file_preserves_unspecified_defaults(self, tmp_path, monkeypatch):
+        cfg = tmp_path / ".config"
+        cfg.write_text(json.dumps({"project_number": 42}))
+        monkeypatch.setattr(github_client, "_CONFIG_PATH", cfg)
+        result = load_config()
+        assert result["project_number"] == 42
+        assert result["owner"] == "AndresI19"       # untouched default
+        assert result["repo"] == "AndresI19/RS-Agent-Planning"
+
+    def test_empty_file_uses_all_defaults(self, tmp_path, monkeypatch):
+        cfg = tmp_path / ".config"
+        cfg.write_text("{}")
+        monkeypatch.setattr(github_client, "_CONFIG_PATH", cfg)
+        result = load_config()
+        assert result["owner"] == "AndresI19"
+        assert result["project_number"] == 5
+
+    def test_returns_dict_with_required_keys(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(github_client, "_CONFIG_PATH", tmp_path / "missing.json")
+        result = load_config()
+        assert {"owner", "project_number", "repo"} <= result.keys()
+
+
+# ── _check_http ────────────────────────────────────────────────────────────────
+
+def _make_response(status_code, body=None, headers=None):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.ok = status_code < 400
+    resp.headers = headers or {}
+    resp.request = MagicMock(method="GET")
+    resp.url = "https://api.github.com/test"
+    resp.text = body or ""
+    if body and body.startswith("{"):
+        try:
+            resp.json.return_value = json.loads(body)
+        except json.JSONDecodeError:
+            resp.json.side_effect = ValueError
+    else:
+        resp.json.side_effect = ValueError
+    return resp
+
+
+class TestCheckHttp:
+    def test_200_passes_silently(self):
+        _check_http(_make_response(200))  # must not raise
+
+    def test_204_passes_silently(self):
+        _check_http(_make_response(204))
+
+    def test_401_exits(self):
+        with pytest.raises(SystemExit):
+            _check_http(_make_response(401))
+
+    def test_403_exits(self):
+        with pytest.raises(SystemExit):
+            _check_http(_make_response(403))
+
+    def test_404_exits(self):
+        with pytest.raises(SystemExit):
+            _check_http(_make_response(404, body='{"message": "Not Found"}'))
+
+    def test_500_exits(self):
+        with pytest.raises(SystemExit):
+            _check_http(_make_response(500))
+
+    def test_403_prints_scopes_when_present(self, capsys):
+        resp = _make_response(403, headers={"X-OAuth-Scopes": "repo,read:org"})
+        with pytest.raises(SystemExit):
+            _check_http(resp)
+        assert "scopes: repo,read:org" in capsys.readouterr().out
+
+    def test_403_no_scopes_header_still_exits(self, capsys):
+        resp = _make_response(403)
+        with pytest.raises(SystemExit):
+            _check_http(resp)
+        out = capsys.readouterr().out
+        assert "Insufficient" in out
+
+
+# ── _check_graphql_errors ──────────────────────────────────────────────────────
+
+class TestCheckGraphqlErrors:
+    def test_unauthorized_type_exits(self):
+        with pytest.raises(SystemExit):
+            _check_graphql_errors([{"type": "UNAUTHORIZED", "message": "Bad credentials"}])
+
+    def test_bad_credentials_in_message_exits(self):
+        with pytest.raises(SystemExit):
+            _check_graphql_errors([{"message": "bad credentials for user"}])
+
+    def test_forbidden_type_exits(self):
+        with pytest.raises(SystemExit):
+            _check_graphql_errors([{"type": "FORBIDDEN", "message": "Not allowed"}])
+
+    def test_generic_error_exits(self):
+        with pytest.raises(SystemExit):
+            _check_graphql_errors([{"message": "Some other GraphQL error"}])
+
+    def test_unauthorized_prints_token_hint(self, capsys):
+        with pytest.raises(SystemExit):
+            _check_graphql_errors([{"type": "UNAUTHORIZED", "message": "Bad credentials"}])
+        assert "invalid or has expired" in capsys.readouterr().out
+
+    def test_multiple_errors_all_reported(self, capsys):
+        errors = [{"message": "Error one"}, {"message": "Error two"}]
+        with pytest.raises(SystemExit):
+            _check_graphql_errors(errors)
+        out = capsys.readouterr().out
+        assert "Error one" in out
+        assert "Error two" in out
+
+
+# ── get_repo_full_name (prs.py) ────────────────────────────────────────────────
+
+class TestGetRepoFullName:
+    def _mock_run(self, url, returncode=0):
+        result = MagicMock()
+        result.returncode = returncode
+        result.stdout = url + "\n"
+        return result
+
+    @patch("prs.subprocess.run")
+    def test_ssh_url_with_dot_git(self, mock_run):
+        mock_run.return_value = self._mock_run("git@github.com:AndresI19/RS-Agent-Planning.git")
+        assert get_repo_full_name(Path("/fake/repo")) == "AndresI19/RS-Agent-Planning"
+
+    @patch("prs.subprocess.run")
+    def test_https_url_with_dot_git(self, mock_run):
+        mock_run.return_value = self._mock_run("https://github.com/AndresI19/RS-Agent-Planning.git")
+        assert get_repo_full_name(Path("/fake/repo")) == "AndresI19/RS-Agent-Planning"
+
+    @patch("prs.subprocess.run")
+    def test_https_url_without_dot_git(self, mock_run):
+        mock_run.return_value = self._mock_run("https://github.com/AndresI19/RS-Agent-Planning")
+        assert get_repo_full_name(Path("/fake/repo")) == "AndresI19/RS-Agent-Planning"
+
+    @patch("prs.subprocess.run")
+    def test_non_github_url_returns_none(self, mock_run):
+        mock_run.return_value = self._mock_run("https://gitlab.com/user/repo.git")
+        assert get_repo_full_name(Path("/fake/repo")) is None
+
+    @patch("prs.subprocess.run")
+    def test_failed_git_command_returns_none(self, mock_run):
+        mock_run.return_value = self._mock_run("", returncode=128)
+        assert get_repo_full_name(Path("/fake/repo")) is None
+
+    @patch("prs.subprocess.run")
+    def test_org_repo_name_preserved(self, mock_run):
+        mock_run.return_value = self._mock_run("git@github.com:some-org/my-repo.git")
+        assert get_repo_full_name(Path("/fake/repo")) == "some-org/my-repo"

--- a/git-tools/tests/test_project_logic.py
+++ b/git-tools/tests/test_project_logic.py
@@ -1,0 +1,336 @@
+"""Tests for project domain logic: items_by_status, advance_ready, set_item_status_by_name,
+loop_state (next_action branching), and wrap_labels layout."""
+import pytest
+from unittest.mock import patch, MagicMock
+from pathlib import Path
+
+from conftest import make_item, make_project_data
+from project import items_by_status, advance_ready, set_item_status_by_name
+from project_state import loop_state
+from list_prs import wrap_labels
+
+
+# ── items_by_status ────────────────────────────────────────────────────────────
+
+class TestItemsByStatus:
+    def test_filters_to_matching_status(self):
+        data = make_project_data([
+            make_item(1, "Task A", "Ready"),
+            make_item(2, "Task B", "Todo"),
+            make_item(3, "Task C", "Ready"),
+        ])
+        result = items_by_status(data, "Ready")
+        assert len(result) == 2
+        assert all(i["status"] == "Ready" for i in result)
+
+    def test_none_filter_returns_all(self):
+        data = make_project_data([
+            make_item(1, "A", "Ready"),
+            make_item(2, "B", "Todo"),
+            make_item(3, "C", "In Progress"),
+        ])
+        assert len(items_by_status(data, None)) == 3
+
+    def test_empty_project_returns_empty(self):
+        assert items_by_status(make_project_data([]), "Ready") == []
+
+    def test_nonexistent_status_returns_empty(self):
+        data = make_project_data([make_item(1, "Task", "Ready")])
+        assert items_by_status(data, "Nonexistent") == []
+
+    def test_skips_items_without_content(self):
+        no_content = {
+            "id": "PVTI_x",
+            "fieldValues": {"nodes": []},
+            "content": None,
+        }
+        data = make_project_data([no_content, make_item(1, "Real", "Ready")])
+        result = items_by_status(data, "Ready")
+        assert len(result) == 1
+        assert result[0]["number"] == 1
+
+    def test_extracts_labels(self):
+        data = make_project_data([
+            make_item(1, "Task", "Ready", labels=["Code", "Service: MCP"])
+        ])
+        result = items_by_status(data, "Ready")
+        assert result[0]["labels"] == ["Code", "Service: MCP"]
+
+    def test_result_fields_present(self):
+        data = make_project_data([make_item(5, "My Task", "Todo")])
+        result = items_by_status(data, "Todo")
+        item = result[0]
+        assert item["item_id"] == "PVTI_5"
+        assert item["number"] == 5
+        assert item["title"] == "My Task"
+        assert item["status"] == "Todo"
+        assert item["state"] == "OPEN"
+        assert "url" in item
+
+    def test_item_with_no_status_fieldvalue_has_none_status(self):
+        item = {
+            "id": "PVTI_99",
+            "fieldValues": {"nodes": []},  # no Status field value
+            "content": {
+                "number": 99, "title": "Statusless", "state": "OPEN",
+                "url": "", "labels": {"nodes": []},
+            },
+        }
+        data = make_project_data([item])
+        result = items_by_status(data, None)
+        assert result[0]["status"] is None
+
+
+# ── advance_ready ──────────────────────────────────────────────────────────────
+
+class TestAdvanceReadyBlockerParsing:
+    """advance_ready reads issue bodies to find '## Blocked By' sections.
+    All GitHub API calls are mocked; project_data uses in-memory fixtures.
+    """
+
+    def _blocked_body(self, *issue_nums):
+        refs = "\n".join(f"- #{n} Some blocker title" for n in issue_nums)
+        return f"Issue description.\n\n## Blocked By\n{refs}"
+
+    @patch("project.set_item_status_by_name")
+    @patch("project.github_client.rest")
+    def test_no_blocked_by_section_promotes(self, mock_rest, mock_set_status):
+        data = make_project_data([make_item(1, "Free Task", "Todo")])
+        mock_rest.return_value = {"body": "Just a description, no blocker section."}
+
+        promoted = advance_ready(data, "owner/repo")
+
+        assert (1, "Free Task") in promoted
+        mock_set_status.assert_called_once()
+
+    @patch("project.set_item_status_by_name")
+    @patch("project.github_client.rest")
+    def test_all_blockers_closed_promotes(self, mock_rest, mock_set_status):
+        data = make_project_data([make_item(2, "Unblocked Task", "Todo")])
+        mock_rest.side_effect = [
+            {"body": self._blocked_body(5, 6)},   # issue body
+            {"state": "closed"},                   # blocker #5
+            {"state": "closed"},                   # blocker #6
+        ]
+
+        promoted = advance_ready(data, "owner/repo")
+
+        assert (2, "Unblocked Task") in promoted
+
+    @patch("project.set_item_status_by_name")
+    @patch("project.github_client.rest")
+    def test_open_blocker_prevents_promotion(self, mock_rest, mock_set_status):
+        data = make_project_data([make_item(3, "Blocked Task", "Todo")])
+        mock_rest.side_effect = [
+            {"body": self._blocked_body(7)},
+            {"state": "open"},
+        ]
+
+        promoted = advance_ready(data, "owner/repo")
+
+        assert promoted == []
+        mock_set_status.assert_not_called()
+
+    @patch("project.set_item_status_by_name")
+    @patch("project.github_client.rest")
+    def test_mixed_blocker_states_prevents_promotion(self, mock_rest, mock_set_status):
+        data = make_project_data([make_item(4, "Half Blocked", "Todo")])
+        mock_rest.side_effect = [
+            {"body": self._blocked_body(8, 9)},
+            {"state": "closed"},
+            {"state": "open"},   # one still open
+        ]
+
+        promoted = advance_ready(data, "owner/repo")
+
+        assert promoted == []
+
+    @patch("project.set_item_status_by_name")
+    @patch("project.github_client.rest")
+    def test_epics_are_skipped_entirely(self, mock_rest, mock_set_status):
+        data = make_project_data([make_item(5, "Big Epic", "Todo", labels=["Epic"])])
+
+        promoted = advance_ready(data, "owner/repo")
+
+        assert promoted == []
+        mock_rest.assert_not_called()
+
+    @patch("project.set_item_status_by_name")
+    @patch("project.github_client.rest")
+    def test_closed_issues_are_skipped(self, mock_rest, mock_set_status):
+        data = make_project_data([make_item(6, "Done", "Todo", state="CLOSED")])
+
+        promoted = advance_ready(data, "owner/repo")
+
+        assert promoted == []
+        mock_rest.assert_not_called()
+
+    @patch("project.set_item_status_by_name")
+    @patch("project.github_client.rest")
+    def test_backlog_items_also_evaluated(self, mock_rest, mock_set_status):
+        data = make_project_data([make_item(7, "Backlog Task", "Backlog")])
+        mock_rest.return_value = {"body": "No blockers."}
+
+        promoted = advance_ready(data, "owner/repo")
+
+        assert (7, "Backlog Task") in promoted
+
+    @patch("project.set_item_status_by_name")
+    @patch("project.github_client.rest")
+    def test_empty_body_promotes(self, mock_rest, mock_set_status):
+        data = make_project_data([make_item(8, "Empty Body", "Todo")])
+        mock_rest.return_value = {"body": None}  # GitHub can return null body
+
+        promoted = advance_ready(data, "owner/repo")
+
+        assert (8, "Empty Body") in promoted
+
+    @patch("project.set_item_status_by_name")
+    @patch("project.github_client.rest")
+    def test_blocked_by_section_not_confused_by_later_headers(self, mock_rest, mock_set_status):
+        body = "## Blocked By\n- #10 Closed blocker\n## Other Section\n- #99 Not a blocker"
+        data = make_project_data([make_item(9, "Ambiguous", "Todo")])
+        mock_rest.side_effect = [
+            {"body": body},
+            {"state": "closed"},  # only #10 should be checked, not #99
+        ]
+
+        promoted = advance_ready(data, "owner/repo")
+
+        assert (9, "Ambiguous") in promoted
+        assert mock_rest.call_count == 2  # body + one blocker check, not three
+
+
+# ── set_item_status_by_name ────────────────────────────────────────────────────
+
+class TestSetItemStatusByName:
+    def test_unknown_status_exits(self):
+        data = make_project_data([])
+        with pytest.raises(SystemExit):
+            set_item_status_by_name(data, "PVTI_1", "InvalidStatus")
+
+    def test_missing_status_field_exits(self):
+        data = {
+            "id": "PVT_test",
+            "fields": {"nodes": []},  # no Status field at all
+            "items": {"nodes": []},
+        }
+        with pytest.raises(SystemExit):
+            set_item_status_by_name(data, "PVTI_1", "Ready")
+
+    @patch("project.set_item_status")
+    def test_valid_status_calls_set_item_status(self, mock_set):
+        data = make_project_data([])
+        set_item_status_by_name(data, "PVTI_1", "Ready")
+        mock_set.assert_called_once_with("PVT_test", "PVTI_1", "field_status", "opt_ready")
+
+    @patch("project.set_item_status")
+    def test_correct_option_id_resolved(self, mock_set):
+        data = make_project_data([])
+        set_item_status_by_name(data, "PVTI_1", "Todo")
+        _, _, _, option_id = mock_set.call_args[0]
+        assert option_id == "opt_todo"
+
+
+# ── loop_state / next_action ───────────────────────────────────────────────────
+
+class TestLoopStateNextAction:
+    """loop_state returns a dict with per-status counts and a next_action signal.
+    query_project and items_by_status are mocked so we only test the branching logic.
+    """
+
+    def _mock_ibs(self, counts_by_status):
+        """Return a side_effect that maps status name → list of N fake items."""
+        def side_effect(data, status):
+            return [None] * counts_by_status.get(status, 0)
+        return side_effect
+
+    @patch("project_state.items_by_status")
+    @patch("project_state.query_project")
+    def test_ready_items_gives_continue(self, mock_qp, mock_ibs):
+        mock_qp.return_value = {}
+        mock_ibs.side_effect = self._mock_ibs({"Ready": 2})
+        assert loop_state()["next_action"] == "continue"
+
+    @patch("project_state.items_by_status")
+    @patch("project_state.query_project")
+    def test_in_progress_items_gives_continue(self, mock_qp, mock_ibs):
+        mock_qp.return_value = {}
+        mock_ibs.side_effect = self._mock_ibs({"In Progress": 1})
+        assert loop_state()["next_action"] == "continue"
+
+    @patch("project_state.items_by_status")
+    @patch("project_state.query_project")
+    def test_only_todo_gives_blocked(self, mock_qp, mock_ibs):
+        mock_qp.return_value = {}
+        mock_ibs.side_effect = self._mock_ibs({"Todo": 3})
+        assert loop_state()["next_action"] == "blocked"
+
+    @patch("project_state.items_by_status")
+    @patch("project_state.query_project")
+    def test_only_backlog_gives_blocked(self, mock_qp, mock_ibs):
+        mock_qp.return_value = {}
+        mock_ibs.side_effect = self._mock_ibs({"Backlog": 1})
+        assert loop_state()["next_action"] == "blocked"
+
+    @patch("project_state.items_by_status")
+    @patch("project_state.query_project")
+    def test_all_empty_gives_plan(self, mock_qp, mock_ibs):
+        mock_qp.return_value = {}
+        mock_ibs.return_value = []
+        assert loop_state()["next_action"] == "plan"
+
+    @patch("project_state.items_by_status")
+    @patch("project_state.query_project")
+    def test_ready_takes_priority_over_todo(self, mock_qp, mock_ibs):
+        # If both Ready and Todo exist, next_action is "continue" not "blocked"
+        mock_qp.return_value = {}
+        mock_ibs.side_effect = self._mock_ibs({"Ready": 1, "Todo": 5})
+        assert loop_state()["next_action"] == "continue"
+
+    @patch("project_state.items_by_status")
+    @patch("project_state.query_project")
+    def test_counts_are_accurate(self, mock_qp, mock_ibs):
+        mock_qp.return_value = {}
+        mock_ibs.side_effect = self._mock_ibs({"Ready": 2, "Todo": 3, "Backlog": 1})
+        result = loop_state()
+        assert result["ready"] == 2
+        assert result["todo"] == 3
+        assert result["backlog"] == 1
+        assert result["in_progress"] == 0
+        assert result["verify"] == 0
+
+
+# ── wrap_labels ────────────────────────────────────────────────────────────────
+
+class TestWrapLabels:
+    """wrap_labels distributes label names into lines that fit within LABEL_WIDTH (28)."""
+
+    def test_empty_list_returns_sentinel(self):
+        assert wrap_labels([]) == [[]]
+
+    def test_single_label(self):
+        assert wrap_labels(["Code"]) == [["Code"]]
+
+    def test_two_short_labels_fit_one_line(self):
+        # "Hi"(4) + gap(1) + "Ok"(4) = 9 < 28
+        assert wrap_labels(["Hi", "Ok"]) == [["Hi", "Ok"]]
+
+    def test_labels_wrap_when_combined_exceeds_width(self):
+        # "Enhancement"(13) + gap(1) + "Documentation"(15) = 29 > 28
+        result = wrap_labels(["Enhancement", "Documentation"])
+        assert result == [["Enhancement"], ["Documentation"]]
+
+    def test_label_that_exactly_fills_width_does_not_wrap(self):
+        # badge_w = 26+2 = 28, fits exactly
+        label = "A" * 26
+        assert wrap_labels([label]) == [[label]]
+
+    def test_three_labels_split_across_lines(self):
+        # "Enhancement"(13) + "Fix"(5) = 13+1+5=19, fits; then "Documentation"(15): 19+1+15=35 > 28
+        result = wrap_labels(["Enhancement", "Fix", "Documentation"])
+        assert result[0] == ["Enhancement", "Fix"]
+        assert result[1] == ["Documentation"]
+
+    def test_single_label_preserves_name(self):
+        assert wrap_labels(["Service: MCP"]) == [["Service: MCP"]]


### PR DESCRIPTION
Shell injection risk in pr.py is eliminated by converting all subprocess invocations from string form to list form, closing the vector entirely. A new pytest suite covers the three-tier library — display helpers, project logic, GitHub client error handling, and URL parsing. Skill instructions are tightened: redundant examples removed, the record skill's terminal steps collapsed into a single FINALIZE section, and the todo skill's stale script path corrected. The README gains a full Skills reference with a summary table and per-skill call stack diagrams.