### PR TITLE
Track project-level commands alongside user skills

### DIFF
--- a/claude/commands/git-plan.md
+++ b/claude/commands/git-plan.md
@@ -1,0 +1,144 @@
+# /git-plan
+
+Generate a top-down GitHub project plan, then create it in GitHub upon approval.
+
+## Pre-flight — Check for an active project
+
+**Before doing anything else**, run both commands:
+
+```bash
+python3 Claude-Project-Tooling/git-tools/interface/advance_ready.py
+python3 Claude-Project-Tooling/git-tools/interface/loop_state.py
+```
+
+`advance_ready.py` surfaces any newly unblocked items. `loop_state.py` returns JSON with `next_action`:
+
+- `"continue"` — Ready or In Progress items exist. Stop and report; the project is still active.
+- `"blocked"` — Todo/Backlog items remain but all blockers are still open. Stop; issues must be resolved first.
+- `"plan"` — all queues empty. Proceed to Phase 1.
+
+---
+
+## Hierarchy
+
+| Level | GitHub object | Scope |
+|-------|--------------|-------|
+| Project | GitHub Project | One sequential deliverable end-to-end (e.g. "Build MCP Server") |
+| Epic | Issue + "Epic" label | 3–12 issues; a coherent chunk of work within a project |
+| Issue | Issue | One deliverable unit, ≤2 tasks, simple and achievable |
+
+**All planning issues, epics, and projects are created in `AndresI19/RS-Agent-Planning`.**
+
+## Phase 1 — Plan (read-only)
+
+Call `EnterPlanMode` immediately before doing anything else.
+
+Then:
+
+1. **Gather context.** Read `RS-Agent-Planning/Planning/project-overview.md`, `architecture.md`, and `tasks.md`. If the user provided a scope as an argument (e.g. `/git-plan MCP Server Phase 1`), focus there. Otherwise ask.
+
+2. **Generate top-down:**
+   - Propose the Project (name + one-line goal)
+   - Break into Epics
+   - For each Epic, draft Issues with labels, status, and explicit blockers
+
+3. **Write the plan** to the plan file in the format below.
+
+4. **Iterate.** Adjust based on feedback, update the plan file, and re-present until approved.
+
+5. Call `ExitPlanMode` to present the plan for final approval.
+
+### Plan File Format
+
+```
+## <Project Name>
+<One sentence: what this project delivers>
+
+### Epic 1: <Title>
+<One sentence: what this epic covers>
+- [ ] <Issue title> — <one-line description> · labels: <label, label> · status: Ready · blocked_by: none
+- [ ] <Issue title> — <one-line description> · labels: <label> · status: Todo · blocked_by: <Issue title>
+- [ ] ...
+
+### Epic 2: ...
+```
+
+**Status rules:**
+- `Ready` — no blocker; can be picked up immediately
+- `Todo` — blocked by one or more specific issues that must complete first
+- `Backlog` — intentionally deferred; not yet in scope for active work
+- Epics always get `Todo` (they track child completion, not active work)
+- Only the first unblocked issue(s) in a dependency chain are `Ready`; everything downstream is `Todo`
+- Issues in later epics that are far from current work should be `Backlog`
+
+**Blocker rules:**
+- List the exact titles of blocking issues in `blocked_by`
+- A blocker must be another issue in this plan
+- Multiple blockers are comma-separated
+- Use `none` when there are no blockers
+
+## Phase 2 — Execute (after ExitPlanMode approval)
+
+Serialize the approved plan into the JSON schema below and run:
+
+```bash
+python3 Claude-Project-Tooling/git-tools/scripts/git-plan.py --meta '<JSON>'
+```
+
+### JSON Schema
+
+```json
+{
+  "project_title": "...",
+  "repo": "AndresI19/RS-Agent-Planning",
+  "epics": [
+    {
+      "title": "...",
+      "description": "One sentence covering what this epic delivers.",
+      "status": "Todo",
+      "issues": [
+        {
+          "title": "...",
+          "description": "One sentence describing the deliverable.",
+          "labels": ["Code", "Service: MCP"],
+          "status": "Ready",
+          "blocked_by": []
+        },
+        {
+          "title": "...",
+          "description": "One sentence describing the deliverable.",
+          "labels": ["Code", "Service: MCP"],
+          "status": "Todo",
+          "blocked_by": ["Title of blocking issue"]
+        }
+      ]
+    }
+  ]
+}
+```
+
+`status` must be one of: `"Ready"`, `"Todo"`, `"Backlog"`. Epics always use `"Todo"`.
+`blocked_by` is a list of issue titles from this plan. Empty list `[]` means no blockers.
+
+The script:
+1. Creates the GitHub Project, Epics, and Issues
+2. Appends a `## Blocked By` section to issue bodies listing resolved issue numbers
+3. Links child issue numbers back into each Epic's checklist body
+4. Adds everything to the project board with the correct initial status
+5. **Only sets status on newly created issues** — existing items are never overwritten on re-runs
+
+## Label Guidelines
+
+Epics always receive the **Epic** label. For issues:
+- **Code** — writing new feature code
+- **Service: MCP** — changes to the MCP server specifically
+- **DevOps** — infra, deployment, CI/CD
+- **Discovery** — investigation needed before work can start
+- **Inquiry** — open design decision that must be resolved first
+- **Defect** — fixing broken behavior
+
+## Constraints
+
+- Epics: minimum 3 issues, maximum 12
+- Issues: maximum 2 sub-tasks; one deliverable per issue
+- Projects: one sequential scope per project; don't mix unrelated deliverables

--- a/claude/commands/new-task.md
+++ b/claude/commands/new-task.md
@@ -1,0 +1,61 @@
+# /new-task
+
+Query the active GitHub project for Ready items and guide the user to pick one to work on.
+
+## Step 1 — Fetch Ready items
+
+Run:
+
+```bash
+python3 Claude-Project-Tooling/git-tools/interface/ready_items.py
+```
+
+Parse the JSON. Each item has: `item_id`, `number`, `title`, `labels`, `url`, `status`.
+
+If the list is empty, print:
+
+```
+No items are currently marked Ready.
+Check the project board to see if items need to be unblocked first.
+```
+
+Then stop.
+
+## Step 2 — Present the options
+
+Display a numbered list of the Ready items. Column order: index, title, labels, issue number. Always append 0) Cancel as the last option.
+
+Example format:
+```
+Ready to work on:
+
+  1)  Resolve stack decisions             [Inquiry]          #6
+  2)  Resolve infrastructure decisions    [Inquiry, DevOps]  #7
+  0)  Cancel
+```
+
+Ask: **"Which would you like to work on? (enter a number)"**
+
+Wait for the user to respond. If they enter 0 or "cancel", stop immediately.
+
+## Step 3 — Show issue context and confirm start
+
+Run:
+
+```bash
+gh issue view NUMBER --repo AndresI19/RS-Agent-Planning
+```
+
+Display the full issue body, then ask: **"Move this to In Progress?"**
+
+If yes:
+
+```bash
+python3 Claude-Project-Tooling/git-tools/interface/set_status.py ITEM_ID "In Progress"
+```
+
+After confirming the status change, briefly suggest what starting looks like based on labels:
+
+- `Code` / `Service: MCP` → create a feature branch and open relevant files
+- `Inquiry` / `Discovery` → read the planning docs and capture a decision
+- `DevOps` → review the infrastructure docs

--- a/claude/commands/work-flow.md
+++ b/claude/commands/work-flow.md
@@ -1,0 +1,101 @@
+# /work-flow
+
+Drive the full project loop: work through all Ready issues, then plan the next project.
+
+## Pre-flight — Advance Ready items
+
+Run advance-ready first so any newly unblocked items surface before the loop starts:
+
+```bash
+python3 Claude-Project-Tooling/git-tools/interface/advance_ready.py
+```
+
+Report any items just promoted. Then enter the loop.
+
+---
+
+## Loop — Work through the Ready queue
+
+Repeat steps 1–6 until the Ready queue is empty. **Do not stop between iterations** — after closing an issue, immediately return to step 1 without waiting for user instruction.
+
+### Step 1 — Fetch Ready items
+
+```bash
+python3 Claude-Project-Tooling/git-tools/interface/ready_items.py
+```
+
+If the list is empty, go to **Transition**.
+
+### Step 2 — Select a task
+
+Display the Ready items in the same numbered format as /new-task. Default to item 1 — state it clearly so the user can redirect:
+
+```
+Continuing with #N — [title]. Enter a different number to switch, or say "go" to proceed.
+```
+
+Wait for confirmation or a redirect before moving on.
+
+### Step 3 — Show issue context
+
+```bash
+gh issue view NUMBER --repo AndresI19/RS-Agent-Planning
+```
+
+Display the full issue body.
+
+### Step 4 — Move to In Progress
+
+```bash
+python3 Claude-Project-Tooling/git-tools/interface/set_status.py ITEM_ID "In Progress"
+```
+
+### Step 5 — Do the work
+
+Work the issue fully based on its labels:
+
+- `Code` / `Service: MCP` → implement the feature; write, test, and verify the code
+- `Inquiry` / `Discovery` → read planning docs, produce a concrete decision or finding, write it up in the appropriate planning file
+- `DevOps` → implement the infrastructure or automation change
+
+Continue until the issue is fully resolved. Surface blockers or open questions to the user as they arise.
+
+### Step 6a — PR gate (must run before closing)
+
+Check the issue labels:
+
+- **Labels include `Code`, `Service: MCP`, or `DevOps`** → **STOP.** Ask the user:
+  > "Want me to open a PR for this?"
+  Wait for an explicit yes or no. If yes, invoke `/pr`. **Do not proceed to Step 6b until this is resolved.**
+- **Labels are only `Inquiry`, `Discovery`, or documentation-only** → skip to Step 6b immediately.
+
+### Step 6b — Close the issue
+
+```bash
+gh issue close NUMBER --repo AndresI19/RS-Agent-Planning
+```
+
+After closing, run advance-ready to surface any newly unblocked items:
+
+```bash
+python3 Claude-Project-Tooling/git-tools/interface/advance_ready.py
+```
+
+Report any promotions, then **immediately return to Step 1**.
+
+---
+
+## Transition — Queue is empty
+
+When the Ready queue is empty and advance-ready promotes nothing:
+
+### Check remaining items
+
+```bash
+python3 Claude-Project-Tooling/git-tools/interface/status_items.py "In Progress"
+python3 Claude-Project-Tooling/git-tools/interface/status_items.py Todo
+python3 Claude-Project-Tooling/git-tools/interface/status_items.py Backlog
+```
+
+- **Items remain in any status** → report the state and stop. Blockers or deferred work may need manual attention before the project can complete.
+- **All queues empty** → the project is done. Invoke /git-plan to plan the next one.


### PR DESCRIPTION
Project-level commands (git-plan, new-task, work-flow) have been living only in the unversioned workspace .claude/commands/ with no git history. This adds claude/commands/ as the tracked source of truth, mirroring the pattern already used for user skills in claude/skills/. The work-flow command also receives a two-step close gate (6a/6b) so the PR offer step cannot be bypassed when finishing Code or DevOps issues.