### PR TITLE
Parameterize home paths and harden issue/PR scripts

### DIFF
--- a/claude/skills/pr/SKILL.md
+++ b/claude/skills/pr/SKILL.md
@@ -21,7 +21,7 @@ Only continue to Step 1 if the user's request is unambiguous.
 
 ## Step 1 — Identify the repo and gather context
 
-From conversation context, determine which single repo under `/home/ClaudeSpace/git-workspace/claude-workspace/` has the changes. Use that path as REPO.
+From conversation context, determine which single repo under `$HOME/git-workspace/claude-workspace/` has the changes. Use that path as REPO.
 
 Run in one command to get the diff context:
 ```bash
@@ -73,7 +73,7 @@ When a `Closes` clause is present, issues must **not** be closed via `gh issue c
 Pass the JSON as a single-quoted string to `--meta`:
 
 ```bash
-python3 /home/ClaudeSpace/git-workspace/claude-workspace/Claude-Project-Tooling/git-tools/scripts/pr.py \
+python3 $HOME/git-workspace/claude-workspace/Claude-Project-Tooling/git-tools/scripts/pr.py \
   --repo REPO \
   --meta 'JSON_HERE'
 ```

--- a/claude/skills/record/SKILL.md
+++ b/claude/skills/record/SKILL.md
@@ -34,7 +34,7 @@ Do **not** proceed with the session log until the user confirms how to handle it
 ## Step 1 — Determine action
 
 ```bash
-python3 /home/ClaudeSpace/git-workspace/claude-workspace/Claude-Project-Tooling/claude/recording/session_detect.py [auto]
+python3 $HOME/git-workspace/claude-workspace/Claude-Project-Tooling/claude/recording/session_detect.py [auto]
 ```
 
 Pass `auto` as the argument if the skill was invoked with `auto`. The script outputs JSON:
@@ -98,7 +98,7 @@ The `## Summary` section contains one `### YYYY-MM-DD HH:MM` subsection per reco
 Run token usage, then push:
 
 ```bash
-python3 /home/ClaudeSpace/git-workspace/claude-workspace/Claude-Project-Tooling/claude/recording/token_usage.py
+python3 $HOME/git-workspace/claude-workspace/Claude-Project-Tooling/claude/recording/token_usage.py
 ```
 
 Replace the session table rows and totals in
@@ -106,7 +106,7 @@ Replace the session table rows and totals in
 and update the "Last updated" date. The script outputs one `| row |` per session file followed by a `TOTALS` line.
 
 ```bash
-python3 /home/ClaudeSpace/git-workspace/claude-workspace/Claude-Project-Tooling/git-tools/scripts/push_sessions.py --message "MESSAGE"
+python3 $HOME/git-workspace/claude-workspace/Claude-Project-Tooling/git-tools/scripts/push_sessions.py --message "MESSAGE"
 ```
 
 Use a short descriptive commit message (e.g. "Update Claude Sessions and token usage"). The script only stages and pushes files under `Claude Sessions/` in RS-Agent-Planning. Claude-Project-Tooling is never touched — script changes there must go through `/pr`.

--- a/git-tools/interface/create_issue.py
+++ b/git-tools/interface/create_issue.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """Create a GitHub issue — stable interface path for the /todo skill.
-Usage: create_issue.py --repo OWNER/REPO --title "..." --body "..." --label Code
+Usage: create_issue.py --repo OWNER/REPO --title "..." --body "..." --label Code [--auto-project]
 """
 import argparse
 import sys
@@ -14,6 +14,9 @@ parser.add_argument("--repo",  required=True)
 parser.add_argument("--title", required=True)
 parser.add_argument("--body",  default="")
 parser.add_argument("--label", action="append", default=[], dest="labels")
+parser.add_argument("--project", action="store_true", default=False,
+                    help="Auto-detect the active GitHub Project and link this issue to it")
 args = parser.parse_args()
 
-create(repo=args.repo, title=args.title, body=args.body, labels=args.labels)
+create(repo=args.repo, title=args.title, body=args.body, labels=args.labels,
+       project=args.project)

--- a/git-tools/scripts/create_issue.py
+++ b/git-tools/scripts/create_issue.py
@@ -4,6 +4,7 @@ create_issue.py — Create a GitHub issue with validated standard labels.
 
 Usage:
     python3 create_issue.py --repo OWNER/REPO --title "..." --body "..." --label Code
+    python3 create_issue.py --repo OWNER/REPO --title "..." --auto-project
 """
 import argparse
 import os
@@ -12,16 +13,29 @@ import sys
 LIB = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "lib")
 sys.path.insert(0, LIB)
 from issues import ISSUE_LABEL_NAMES, get_or_create_issue
+from project import find_active_project, get_project_node_id, add_item_to_project
 
 
-def create(repo, title, body, labels):
+def create(repo, title, body, labels, project=False):
     """Create a GitHub issue and print its URL. Returns the URL string."""
     invalid = [l for l in labels if l not in ISSUE_LABEL_NAMES]
     if invalid:
         print(f"ERROR: unknown label(s): {', '.join(invalid)}")
         print(f"  Valid labels: {', '.join(ISSUE_LABEL_NAMES)}")
         sys.exit(1)
-    _, url, _, _ = get_or_create_issue(repo, title, body, labels)
+
+    _, url, node_id, _ = get_or_create_issue(repo, title, body, labels)
+
+    if project:
+        owner = repo.split("/")[0]
+        active = find_active_project(owner)
+        if active:
+            project_id = get_project_node_id(owner, active["number"])
+            add_item_to_project(project_id, node_id)
+            print(f"Linked to project: {active['title']}")
+        else:
+            print("Warning: no active project found — issue not linked to a project")
+
     print(url)
     return url
 
@@ -33,16 +47,17 @@ def main():
     parser.add_argument("--body",  default="",    help="Issue body")
     parser.add_argument("--label", action="append", default=[], dest="labels",
                         metavar="LABEL", help="Label name (repeatable)")
+    parser.add_argument("--project", action="store_true", default=False,
+                        help="Auto-detect the active GitHub Project and link this issue to it")
     args = parser.parse_args()
 
-    invalid = [l for l in args.labels if l not in ISSUE_LABEL_NAMES]
-    if invalid:
-        print(f"ERROR: unknown label(s): {', '.join(invalid)}")
-        print(f"  Valid labels: {', '.join(ISSUE_LABEL_NAMES)}")
-        sys.exit(1)
-
-    _, url, _, _ = get_or_create_issue(args.repo, args.title, args.body, args.labels)
-    print(url)
+    create(
+        repo=args.repo,
+        title=args.title,
+        body=args.body,
+        labels=args.labels,
+        project=args.project,
+    )
 
 
 if __name__ == "__main__":

--- a/git-tools/scripts/pr.py
+++ b/git-tools/scripts/pr.py
@@ -176,10 +176,25 @@ def main():
     )
     print(f"\nPR: {pr_url}")
 
-    # Apply labels
+    # Apply labels — auto-init defaults on remote if any are missing
     if labels:
         pr_number = pr_url.rstrip("/").split("/")[-1]
-        run(["gh", "pr", "edit", pr_number, "--repo", gh_repo, "--add-label", ",".join(labels)], cwd=repo)
+        label_result = subprocess.run(
+            ["gh", "pr", "edit", pr_number, "--repo", gh_repo, "--add-label", ",".join(labels)],
+            cwd=repo, capture_output=True, text=True,
+        )
+        if label_result.returncode != 0:
+            if "not found" in label_result.stderr:
+                print("Labels missing on remote — initializing defaults...")
+                init_script = str(Path(__file__).parent / "init_labels.py")
+                run([sys.executable, init_script, "--repo", gh_repo], cwd=repo)
+                run(["gh", "pr", "edit", pr_number, "--repo", gh_repo, "--add-label", ",".join(labels)], cwd=repo)
+            else:
+                print(f"\nERROR: command failed (exit {label_result.returncode})")
+                print(f"  CMD:    gh pr edit {pr_number} --repo {gh_repo} --add-label {','.join(labels)}")
+                if label_result.stderr.strip():
+                    print(f"  STDERR: {label_result.stderr.strip()}")
+                sys.exit(1)
         print(f"Labels: {', '.join(labels)}")
 
     # PR list


### PR DESCRIPTION
Skill instructions now reference $HOME instead of a hardcoded user path so commands resolve correctly regardless of the actual home directory or Claude's current working directory. Issue creation gains a --project flag that auto-detects the active GitHub Project for the owning org and links new issues to it, used by /todo for the RS-Agent-Planning board. PR creation now detects when label application fails because the remote lacks the standard label set and runs init_labels.py to create them before retrying, so first-time PRs against fresh repos no longer fail at the label step.