### PR TITLE
Add branch-per-task, resume, Verify, and plan-mode kickoff

### DIFF
--- a/claude/commands/new-task.md
+++ b/claude/commands/new-task.md
@@ -1,61 +1,171 @@
 # /new-task
 
-Query the active GitHub project for Ready items and guide the user to pick one to work on.
+Pick the next task to work on, create its branch, and (for code tasks) enter plan mode with full issue context.
 
-## Step 1 — Fetch Ready items
-
-Run:
+## Step 1 — Build the unified task list
 
 ```bash
-python3 Claude-Project-Tooling/git-tools/interface/ready_items.py
+python3 $HOME/git-workspace/claude-workspace/Claude-Project-Tooling/git-tools/interface/ready_items.py --include-statuses="Verify,In Progress,Ready"
 ```
 
 Parse the JSON. Each item has: `item_id`, `number`, `title`, `labels`, `url`, `status`.
 
-If the list is empty, print:
+Render one numbered list. Each entry includes a link emoji to the GitHub issue. Color-code the trailing status chip:
+- `Verify` → **yellow** (`\033[33m`)
+- `In Progress` → **cyan** (`\033[36m`)
+- `Ready` → default
 
+Format example:
 ```
-No items are currently marked Ready.
-Check the project board to see if items need to be unblocked first.
-```
+Pick a task:
 
-Then stop.
-
-## Step 2 — Present the options
-
-Display a numbered list of the Ready items. Column order: index, title, labels, issue number. Always append 0) Cancel as the last option.
-
-Example format:
-```
-Ready to work on:
-
-  1)  Resolve stack decisions             [Inquiry]          #6
-  2)  Resolve infrastructure decisions    [Inquiry, DevOps]  #7
-  0)  Cancel
+  1) [🔗](https://github.com/AndresI19/RS-Agent-Planning/issues/27) Issue #27 — Add sanity tests for health and crash    [Verify]
+  2) [🔗](https://github.com/AndresI19/RS-Agent-Planning/issues/13) Issue #13 — Implement get_player_stats tool         [In Progress]
+  3) [🔗](https://github.com/AndresI19/RS-Agent-Planning/issues/14) Issue #14 — Implement get_quest_info tool           [Ready]
+  0) Cancel
 ```
 
-Ask: **"Which would you like to work on? (enter a number)"**
+If the terminal does not render markdown links, the URL appears as plain text after the 🔗 — keep the emoji either way.
 
-Wait for the user to respond. If they enter 0 or "cancel", stop immediately.
+**Default selection**: first **Ready** item if any exist; otherwise first **In Progress** item.
 
-## Step 3 — Show issue context and confirm start
+Ask: **"Which? (number, or 0 to cancel)"** — wait for the user.
 
-Run:
+If the user picks a **Verify** item, prompt:
+> "This issue is in Verify. Open the PR / read the work and close the issue if approved, or pick another item."
+
+Do not proceed past Step 1 for a Verify selection unless the user explicitly says to re-open the work.
+
+## Step 2 — Infer target repo
+
+RS-Agent-Planning holds **planning artifacts only** — never PRs (except those by `/todo`). Code work always happens in a code repo under `~/git-workspace/claude-workspace/`.
+
+**Discover code repos** in the workspace:
+```bash
+find $HOME/git-workspace/claude-workspace -mindepth 2 -maxdepth 2 -name .git -type d 2>/dev/null \
+  | xargs -n1 dirname | xargs -n1 basename | grep -v '^RS-Agent-Planning$'
+```
+
+**Inference rules**:
+1. **`Service: <name>` labels** map deterministically: `Service: MCP` → `rs-mcp-server`. Convention: repo name is `rs-<name>` (lowercase). Future labels follow the same pattern.
+2. **Generic code labels** (`Code` / `DevOps` / `Defect` without a `Service:` qualifier): infer from the issue body — file paths, repo names mentioned, or contextual clues. If unambiguous, proceed; if ambiguous, prompt the user with the discovered candidates as a numbered list.
+3. **`Inquiry` / `Discovery` only** (no other code label): work on planning docs in `RS-Agent-Planning`. Print the caution banner below and skip Steps 3–4.
+
+State the inferred repo to the user before proceeding so it can be redirected.
+
+### Inquiry/Discovery caution
+
+When the chosen issue routes to RS-Agent-Planning (planning docs only), print:
+```
+⚠ Inquiry/Discovery task — no branch will be created.
+  Edits land on RS-Agent-Planning main and ride along with the next /record push.
+```
+
+Then jump to Step 5.
+
+## Step 3 — Resume detection (code-bearing tasks only)
+
+The branch naming convention bakes the issue number in (`-I<N>` suffix), so the branch itself is the resume key — no separate cache needed.
 
 ```bash
-gh issue view NUMBER --repo AndresI19/RS-Agent-Planning
+git -C $HOME/git-workspace/claude-workspace/<repo> fetch origin --quiet
+git -C $HOME/git-workspace/claude-workspace/<repo> branch --all --format='%(refname:short)' \
+  | grep -E "(^|/)[A-Za-z0-9-]+-I${ISSUE_NUMBER}$" \
+  | head -1
 ```
 
-Display the full issue body, then ask: **"Move this to In Progress?"**
+- **Match found** → **Resume**:
+  - Capture the branch name and any associated open PR:
+    ```bash
+    gh pr list --head <branch> --repo AndresI19/<repo> --json number,url
+    ```
+  - Switch to that branch: `git -C <repo> checkout <branch>` (handle pre-flight first if working tree is dirty — see Step 3b)
+  - Skip Step 4 (no new branch creation)
+- **No match** → continue to Step 3b, then Step 4
 
-If yes:
+## Step 3b — Pre-flight: handle uncommitted changes
 
 ```bash
-python3 Claude-Project-Tooling/git-tools/interface/set_status.py ITEM_ID "In Progress"
+git -C <repo> status --short
+git -C <repo> branch --show-current
 ```
 
-After confirming the status change, briefly suggest what starting looks like based on labels:
+**If working tree is clean and current branch is `main`** → skip to Step 4.
 
-- `Code` / `Service: MCP` → create a feature branch and open relevant files
-- `Inquiry` / `Discovery` → read the planning docs and capture a decision
-- `DevOps` → review the infrastructure docs
+**Otherwise**, present this 4-option prompt:
+
+```
+The current branch (<branch>) has uncommitted changes:
+  <git status output>
+
+How should we proceed?
+  1) Open a PR for these changes (invokes /pr, then continues on a new branch)
+  2) Cancel — finish current work first
+  3) Commit current changes and continue on this same branch (no new branch)
+  4) Preserve current changes (commit OR stash) and start a new branch
+```
+
+- **Option 1** → invoke `/pr` skill → after PR succeeds, continue to Step 4
+- **Option 2** → exit `/new-task` cleanly, do not move issue to In Progress
+- **Option 3** → ask for a one-line commit message → `git -C <repo> commit -am "<msg>"` → skip Step 4 → continue to Step 5
+- **Option 4** → sub-prompt: `(a) commit  (b) stash` → execute the chosen action, then continue to Step 4. If stash, remember to `git -C <repo> stash pop` after Step 4.
+
+## Step 4 — Create the task branch
+
+**Branch naming**: 2–3 word kebab-case descriptor of the issue + `-I<N>` suffix.
+Examples: `server-refactoring-I19`, `endpoint-documentation-I20`, `fix-redis-timeout-I40`.
+
+Print the proposed name. If a local branch with that exact name already exists (collision unrelated to resume), append `-2`, `-3`, etc.
+
+Create off the latest `origin/main` in one shot — no intermediate `git checkout main`:
+```bash
+git -C <repo> fetch origin main --quiet
+git -C <repo> checkout -b <branch-name> origin/main
+```
+
+If Step 3b chose Option 4 with stash → `git -C <repo> stash pop`.
+
+## Step 5 — Move issue to In Progress
+
+Skipped on resume (already In Progress).
+
+```bash
+python3 $HOME/git-workspace/claude-workspace/Claude-Project-Tooling/git-tools/interface/set_status.py ITEM_ID "In Progress"
+```
+
+## Step 6 — Plan mode trigger (with full context kickoff)
+
+- Labels include `Code` / `Service: MCP` / `DevOps` → **automatically call `EnterPlanMode`**
+- Labels are only `Inquiry` / `Discovery` / docs → **ask the user**: "Enter plan mode for this task? (y/N)"
+
+**On entering plan mode, immediately fetch issue context and print the kickoff block**:
+
+```bash
+python3 $HOME/git-workspace/claude-workspace/Claude-Project-Tooling/git-tools/interface/issue_context.py NUMBER --repo AndresI19/RS-Agent-Planning
+```
+
+Print:
+```
+🧭 Plan mode for issue #N — <title>
+   Issue:  [🔗](<url>)
+   Branch: <branch-name>          (resumed from <last commit short sha> · PR #M open)
+                                  — or — (fresh from origin/main)
+   Repo:   <inferred repo>
+
+📋 Recap
+   <2–4 sentence summary of the issue body>
+
+💬 Comments (most recent first)
+   - @user (date): <first 200 chars of comment>
+   - @user (date): <first 200 chars of comment>
+```
+
+For the resume status line, run `git -C <repo> log -1 --pretty='%h'` to get the short sha, and `gh pr list --head <branch> --json number` to detect any open PR.
+
+**Once the user approves the plan, immediately call `ExitPlanMode` to begin implementation. Do not begin coding while still in plan mode.**
+
+## Step 7 — Do the work
+
+- `Code` / `Service: MCP` → implement the feature; write, test, verify
+- `Inquiry` / `Discovery` → read planning docs, produce a concrete decision, write it up
+- `DevOps` → implement the infrastructure or automation change

--- a/claude/commands/new-task.md
+++ b/claude/commands/new-task.md
@@ -10,24 +10,38 @@ python3 $HOME/git-workspace/claude-workspace/Claude-Project-Tooling/git-tools/in
 
 Parse the JSON. Each item has: `item_id`, `number`, `title`, `labels`, `url`, `status`.
 
-Render one numbered list. Each entry includes a link emoji to the GitHub issue. Color-code the trailing status chip:
-- `Verify` → **yellow** (`\033[33m`)
-- `In Progress` → **cyan** (`\033[36m`)
-- `Ready` → default
+**Render the menu as markdown in your text response — not via Bash printf.** Bash outputs over a few lines get auto-folded and the user has to expand them; markdown in your text response is always visible and supports hyperlinks.
 
-Format example:
+Status is conveyed by an **emoji indicator** at the start of each row (no color column, no padding):
+- `Verify` → 🟡
+- `In Progress` → 🔵
+- `Ready` → ⚪
+
+The issue number is the link, rendered as a markdown hyperlink at the end of the line.
+
+**Pagination**: show **20 items per page**. If more items remain, the line just above `0. Cancel` is `21. → List more (N remaining)` (numbering continues across pages, e.g. items 21–40 on page 2 keep numbers 21–40).
+
+**Number formatting**: do NOT use a markdown ordered list (`1.`, `2.`, …) — its renderer doesn't pad single-digit numbers to align with double-digit ones, so emoji shift right at item 10+. Instead, render each row as a paragraph line with the number wrapped in backticks and **left-padded with one space when the total max number is two digits** (so ` 1.` aligns with `10.`). This puts all status emoji on the same column.
+
+Format example (markdown in your text response):
 ```
-Pick a task:
+**Pick a task** (page 1 of 3):
 
-  1) [🔗](https://github.com/AndresI19/RS-Agent-Planning/issues/27) Issue #27 — Add sanity tests for health and crash    [Verify]
-  2) [🔗](https://github.com/AndresI19/RS-Agent-Planning/issues/13) Issue #13 — Implement get_player_stats tool         [In Progress]
-  3) [🔗](https://github.com/AndresI19/RS-Agent-Planning/issues/14) Issue #14 — Implement get_quest_info tool           [Ready]
-  0) Cancel
+` 1.` 🟡 Add sanity tests for health and crash · [#27](https://github.com/AndresI19/RS-Agent-Planning/issues/27)
+` 2.` 🔵 Implement search_wiki tool · [#11](https://github.com/AndresI19/RS-Agent-Planning/issues/11)
+` 3.` ⚪ Implement get_player_stats tool · [#13](https://github.com/AndresI19/RS-Agent-Planning/issues/13)
+` 4.` ⚪ Implement get_quest_info tool · [#14](https://github.com/AndresI19/RS-Agent-Planning/issues/14)
+` 5.` ⚪ Add in-memory cache with per-tool TTLs · [#15](https://github.com/AndresI19/RS-Agent-Planning/issues/15)
+` 6.` ⚪ Test all tools via mcp dev inspector · [#16](https://github.com/AndresI19/RS-Agent-Planning/issues/16)
+`21.` → List more (N remaining)
+` 0.` Cancel
+
+Legend: 🟡 Verify · 🔵 In Progress · ⚪ Ready
 ```
 
-If the terminal does not render markdown links, the URL appears as plain text after the 🔗 — keep the emoji either way.
+Pad widths to whatever max is needed: 2 digits when the menu has 10–99 items, 3 digits for 100+. Single-digit-only menus need no padding.
 
-**Default selection**: first **Ready** item if any exist; otherwise first **In Progress** item.
+Keep the `user-select.wav` sound on selection prompts (play via Bash before rendering the menu).
 
 Ask: **"Which? (number, or 0 to cancel)"** — wait for the user.
 

--- a/claude/commands/work-flow.md
+++ b/claude/commands/work-flow.md
@@ -20,7 +20,7 @@ Repeat steps 1–7 until the queue is empty. **Do not stop between iterations** 
 
 Run the full `/new-task` flow for each iteration. This handles, in order:
 - Building the unified Verify/In Progress/Ready list (with link emojis and color-coded status chips)
-- Selecting an item (default: first Ready)
+- Selecting an item
 - Inferring the target repo
 - Resume detection (existing branch with `-I<N>` suffix)
 - Pre-flight uncommitted-changes prompt (4 options)

--- a/claude/commands/work-flow.md
+++ b/claude/commands/work-flow.md
@@ -1,84 +1,59 @@
 # /work-flow
 
-Drive the full project loop: work through all Ready issues, then plan the next project.
+Drive the project loop: work through Verify, In Progress, and Ready issues, then plan the next project.
 
 ## Pre-flight — Advance Ready items
 
-Run advance-ready first so any newly unblocked items surface before the loop starts:
-
 ```bash
-python3 Claude-Project-Tooling/git-tools/interface/advance_ready.py
+python3 $HOME/git-workspace/claude-workspace/Claude-Project-Tooling/git-tools/interface/advance_ready.py
 ```
 
 Report any items just promoted. Then enter the loop.
 
 ---
 
-## Loop — Work through the Ready queue
+## Loop — Work through the queue
 
-Repeat steps 1–6 until the Ready queue is empty. **Do not stop between iterations** — after closing an issue, immediately return to step 1 without waiting for user instruction.
+Repeat steps 1–7 until the queue is empty. **Do not stop between iterations** — after moving an issue to Verify, immediately return to step 1 without waiting for user instruction.
 
-### Step 1 — Fetch Ready items
+### Steps 1–6 — Delegate to /new-task
 
-```bash
-python3 Claude-Project-Tooling/git-tools/interface/ready_items.py
-```
-
-If the list is empty, go to **Transition**.
-
-### Step 2 — Select a task
-
-Display the Ready items in the same numbered format as /new-task. Default to item 1 — state it clearly so the user can redirect:
-
-```
-Continuing with #N — [title]. Enter a different number to switch, or say "go" to proceed.
-```
-
-Wait for confirmation or a redirect before moving on.
-
-### Step 3 — Show issue context
-
-```bash
-gh issue view NUMBER --repo AndresI19/RS-Agent-Planning
-```
-
-Display the full issue body.
-
-### Step 4 — Move to In Progress
-
-```bash
-python3 Claude-Project-Tooling/git-tools/interface/set_status.py ITEM_ID "In Progress"
-```
-
-### Step 5 — Do the work
-
-Work the issue fully based on its labels:
-
-- `Code` / `Service: MCP` → implement the feature; write, test, and verify the code
-- `Inquiry` / `Discovery` → read planning docs, produce a concrete decision or finding, write it up in the appropriate planning file
-- `DevOps` → implement the infrastructure or automation change
+Run the full `/new-task` flow for each iteration. This handles, in order:
+- Building the unified Verify/In Progress/Ready list (with link emojis and color-coded status chips)
+- Selecting an item (default: first Ready)
+- Inferring the target repo
+- Resume detection (existing branch with `-I<N>` suffix)
+- Pre-flight uncommitted-changes prompt (4 options)
+- Branch creation off `origin/main`
+- Moving the issue to In Progress
+- Plan mode kickoff with full context (issue link, branch, recap, comments)
+- Doing the work end to end
 
 Continue until the issue is fully resolved. Surface blockers or open questions to the user as they arise.
 
-### Step 6a — PR gate (must run before closing)
+### Step 7a — PR gate (must run before transitioning)
 
 Check the issue labels:
 
 - **Labels include `Code`, `Service: MCP`, or `DevOps`** → **STOP.** Ask the user:
   > "Want me to open a PR for this?"
-  Wait for an explicit yes or no. If yes, invoke `/pr`. **Do not proceed to Step 6b until this is resolved.**
-- **Labels are only `Inquiry`, `Discovery`, or documentation-only** → skip to Step 6b immediately.
+  Wait for an explicit yes or no. If yes, invoke `/pr`. **Do not proceed to Step 7b until this is resolved.**
+- **Labels are only `Inquiry`, `Discovery`, or documentation-only** → skip to Step 7b immediately.
 
-### Step 6b — Close the issue
+### Step 7b — Move issue to Verify
+
+Do **not** `gh issue close`. Instead, move the issue to Verify so the user reviews before it's closed:
 
 ```bash
-gh issue close NUMBER --repo AndresI19/RS-Agent-Planning
+python3 $HOME/git-workspace/claude-workspace/Claude-Project-Tooling/git-tools/interface/set_status.py ITEM_ID "Verify"
 ```
 
-After closing, run advance-ready to surface any newly unblocked items:
+The user closes the issue manually after reviewing the work / merging the PR. Verify items appear at the top of the next iteration's task list (yellow chip), so they remain visible as a reminder until acted on.
+
+After moving to Verify, run advance-ready to surface any newly unblocked items:
 
 ```bash
-python3 Claude-Project-Tooling/git-tools/interface/advance_ready.py
+python3 $HOME/git-workspace/claude-workspace/Claude-Project-Tooling/git-tools/interface/advance_ready.py
 ```
 
 Report any promotions, then **immediately return to Step 1**.
@@ -87,14 +62,13 @@ Report any promotions, then **immediately return to Step 1**.
 
 ## Transition — Queue is empty
 
-When the Ready queue is empty and advance-ready promotes nothing:
+When the unified queue (Verify + In Progress + Ready) is empty and advance-ready promotes nothing:
 
 ### Check remaining items
 
 ```bash
-python3 Claude-Project-Tooling/git-tools/interface/status_items.py "In Progress"
-python3 Claude-Project-Tooling/git-tools/interface/status_items.py Todo
-python3 Claude-Project-Tooling/git-tools/interface/status_items.py Backlog
+python3 $HOME/git-workspace/claude-workspace/Claude-Project-Tooling/git-tools/interface/status_items.py Todo
+python3 $HOME/git-workspace/claude-workspace/Claude-Project-Tooling/git-tools/interface/status_items.py Backlog
 ```
 
 - **Items remain in any status** → report the state and stop. Blockers or deferred work may need manual attention before the project can complete.

--- a/claude/skills/todo/SKILL.md
+++ b/claude/skills/todo/SKILL.md
@@ -60,11 +60,48 @@ From the input text, derive:
 Run:
 
 ```bash
-python3 Claude-Project-Tooling/git-tools/interface/create_issue.py \
+python3 $HOME/git-workspace/claude-workspace/Claude-Project-Tooling/git-tools/interface/create_issue.py \
   --repo AndresI19/TARGETREPO \
   --title "TITLE" \
   --body "DESCRIPTION" \
-  --label LABEL1 --label LABEL2
+  --label LABEL1 --label LABEL2 \
+  [--project]
 ```
 
-Omit `--label` flags if no labels apply. Print the issue URL when done.
+- Include `--project` when TARGETREPO is **RS-Agent-Planning** — this detects the active GitHub Project and links the issue to it automatically.
+- Omit `--project` for **Claude-Project-Tooling** (no active project board).
+- Omit `--label` flags if no labels apply.
+
+When `--project` is used, the script prints `ITEM_ID: <id>` followed by the issue URL. **Capture both.**
+
+## Step 5 — Set initial project status (RS-Agent-Planning only)
+
+Skip this step entirely for Claude-Project-Tooling.
+
+For RS-Agent-Planning, decide between **Todo** (queued, blocked by other work) and **Ready** (can be picked up immediately) by inferring sequential dependencies from existing project items.
+
+Fetch all current open project items:
+
+```bash
+python3 $HOME/git-workspace/claude-workspace/Claude-Project-Tooling/git-tools/interface/ready_items.py \
+  --include-statuses="In Progress,Ready,Todo,Backlog"
+```
+
+Read the new issue's intent against the open items' titles. Apply this rule:
+
+- The new task **logically depends on** another open item (it can only be done after that item completes — e.g., "deploy the server" depends on "provision hosting") → set status to **Todo**
+- Otherwise → set status to **Ready**
+
+Then run:
+
+```bash
+python3 $HOME/git-workspace/claude-workspace/Claude-Project-Tooling/git-tools/interface/set_status.py ITEM_ID "Todo"
+# or
+python3 $HOME/git-workspace/claude-workspace/Claude-Project-Tooling/git-tools/interface/set_status.py ITEM_ID "Ready"
+```
+
+Do this silently — do not prompt the user. The chosen status appears in the final URL print.
+
+## Step 6 — Print the result
+
+Print the issue URL and the chosen initial status (if applicable).

--- a/git-tools/interface/issue_context.py
+++ b/git-tools/interface/issue_context.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Fetch issue title, body, labels, and comments for plan-mode context.
+
+Usage:
+    issue_context.py NUMBER --repo OWNER/REPO
+
+Output: JSON with title, body, labels, url, state, number, comments.
+Each comment has: author, created_at, body.
+"""
+import argparse
+import json
+import subprocess
+import sys
+
+parser = argparse.ArgumentParser()
+parser.add_argument("number", type=int)
+parser.add_argument("--repo", required=True, help="OWNER/REPO")
+args = parser.parse_args()
+
+result = subprocess.run(
+    ["gh", "issue", "view", str(args.number), "--repo", args.repo,
+     "--json", "title,body,labels,comments,url,state,number"],
+    capture_output=True, text=True,
+)
+if result.returncode != 0:
+    print(f"ERROR: {result.stderr.strip()}", file=sys.stderr)
+    sys.exit(1)
+
+data = json.loads(result.stdout)
+data["labels"] = [l.get("name", "") for l in data.get("labels", [])]
+data["comments"] = [
+    {
+        "author": c.get("author", {}).get("login", "unknown"),
+        "created_at": c.get("createdAt", ""),
+        "body": c.get("body", ""),
+    }
+    for c in data.get("comments", [])
+]
+print(json.dumps(data, indent=2))

--- a/git-tools/interface/ready_items.py
+++ b/git-tools/interface/ready_items.py
@@ -1,10 +1,23 @@
 #!/usr/bin/env python3
-"""List Ready project items as JSON — pre-set interface for skill consumption."""
-import os
+"""List project items as JSON — pre-set interface for skill consumption.
+
+Default: Ready items only (backward compatible).
+Pass --include-statuses to fetch multiple statuses in display priority order.
+Examples:
+    ready_items.py
+    ready_items.py --include-statuses="Verify,In Progress,Ready"
+"""
+import argparse
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 from project_items import list_items
 
-list_items(status="Ready", json_output=True)
+parser = argparse.ArgumentParser()
+parser.add_argument("--include-statuses", default="Ready",
+                    help="Comma-separated statuses in display priority order")
+args = parser.parse_args()
+
+statuses = [s.strip() for s in args.include_statuses.split(",")]
+list_items(statuses=statuses, json_output=True)

--- a/git-tools/interface/status_items.py
+++ b/git-tools/interface/status_items.py
@@ -12,4 +12,4 @@ if len(sys.argv) < 2:
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 from project_items import list_items
 
-list_items(status=sys.argv[1], json_output=True)
+list_items(statuses=[sys.argv[1]], json_output=True)

--- a/git-tools/lib/project.py
+++ b/git-tools/lib/project.py
@@ -13,6 +13,18 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import github_client
 
 
+# ── Status name constants ─────────────────────────────────────────────────────
+# These mirror the column names in the GitHub Project board. Keeping them
+# centralized means a project rename only requires one edit.
+
+STATUS_BACKLOG     = "Backlog"
+STATUS_TODO        = "Todo"
+STATUS_READY       = "Ready"
+STATUS_IN_PROGRESS = "In Progress"
+STATUS_VERIFY      = "Verify"
+STATUS_DONE        = "Done"
+
+
 # ── Query helpers ──────────────────────────────────────────────────────────────
 
 def query_project(owner, project_number):
@@ -303,7 +315,7 @@ def advance_ready(project_data, repo):
     """
     candidates = [
         item for item in items_by_status(project_data, None)
-        if item["status"] in ("Todo", "Backlog")
+        if item["status"] in (STATUS_TODO, STATUS_BACKLOG)
         and item["state"] == "OPEN"
         and "Epic" not in item["labels"]
     ]
@@ -324,6 +336,6 @@ def advance_ready(project_data, repo):
             ]
             if not all(s == "closed" for s in states):
                 continue
-        set_item_status_by_name(project_data, item["item_id"], "Ready")
+        set_item_status_by_name(project_data, item["item_id"], STATUS_READY)
         promoted.append((item["number"], item["title"]))
     return promoted

--- a/git-tools/scripts/create_issue.py
+++ b/git-tools/scripts/create_issue.py
@@ -29,12 +29,13 @@ def create(repo, title, body, labels, project=False):
     if project:
         owner = repo.split("/")[0]
         active = find_active_project(owner)
-        if active:
-            project_id = get_project_node_id(owner, active["number"])
-            add_item_to_project(project_id, node_id)
-            print(f"Linked to project: {active['title']}")
-        else:
-            print("Warning: no active project found — issue not linked to a project")
+        if not active:
+            print(f"ERROR: --project requested but no active project found for owner '{owner}'")
+            sys.exit(1)
+        project_id = get_project_node_id(owner, active["number"])
+        item_id = add_item_to_project(project_id, node_id)
+        print(f"Linked to project: {active['title']}")
+        print(f"ITEM_ID: {item_id}")
 
     print(url)
     return url

--- a/git-tools/scripts/project_items.py
+++ b/git-tools/scripts/project_items.py
@@ -52,15 +52,25 @@ def print_table(items, status_label):
     print(f"  {BOLD}0){RESET}  Cancel\n")
 
 
-def list_items(status="Ready", json_output=False,
+def list_items(status=None, statuses=None, json_output=False,
                owner=_OWNER, project_number=_PROJECT_NUMBER):
-    """List project items for a given status. Prints table or JSON."""
+    """List project items for one or more statuses.
+
+    Pass `status` for single-status (legacy), or `statuses` (list) for multi-status.
+    Multi-status results are sorted by the order of `statuses`, then by item number.
+    """
+    if statuses is None:
+        statuses = [status] if status else ["Ready"]
     project_data = query_project(owner, project_number)
-    items = items_by_status(project_data, status)
+    all_items = items_by_status(project_data, status_filter=None)
+    wanted = set(statuses)
+    items = [i for i in all_items if i["status"] in wanted]
+    priority = {s: idx for idx, s in enumerate(statuses)}
+    items.sort(key=lambda x: (priority.get(x["status"], 999), x.get("number") or 0))
     if json_output:
         print(json.dumps(items, indent=2))
     else:
-        print_table(items, status)
+        print_table(items, ", ".join(statuses))
 
 
 def update_status(item_id, target,
@@ -75,7 +85,10 @@ def main():
     parser = argparse.ArgumentParser(description="Query and update GitHub Project items")
     parser.add_argument("--owner",          default=_OWNER)
     parser.add_argument("--project-number", type=int, default=_PROJECT_NUMBER)
-    parser.add_argument("--status",         default="Ready")
+    parser.add_argument("--status",         default=None,
+                        help="Single status filter (legacy). Defaults to Ready when neither flag is set.")
+    parser.add_argument("--include-statuses", default=None,
+                        help="Comma-separated statuses in display priority order. Overrides --status.")
     parser.add_argument("--json",           action="store_true")
     parser.add_argument("--set-status",     nargs=2, metavar=("ITEM_ID", "STATUS"))
     args = parser.parse_args()
@@ -84,7 +97,8 @@ def main():
         update_status(args.set_status[0], args.set_status[1],
                       owner=args.owner, project_number=args.project_number)
     else:
-        list_items(status=args.status, json_output=args.json,
+        statuses = [s.strip() for s in args.include_statuses.split(",")] if args.include_statuses else None
+        list_items(status=args.status, statuses=statuses, json_output=args.json,
                    owner=args.owner, project_number=args.project_number)
 
 

--- a/git-tools/scripts/project_items.py
+++ b/git-tools/scripts/project_items.py
@@ -52,15 +52,9 @@ def print_table(items, status_label):
     print(f"  {BOLD}0){RESET}  Cancel\n")
 
 
-def list_items(status=None, statuses=None, json_output=False,
+def list_items(statuses=("Ready",), json_output=False,
                owner=_OWNER, project_number=_PROJECT_NUMBER):
-    """List project items for one or more statuses.
-
-    Pass `status` for single-status (legacy), or `statuses` (list) for multi-status.
-    Multi-status results are sorted by the order of `statuses`, then by item number.
-    """
-    if statuses is None:
-        statuses = [status] if status else ["Ready"]
+    """List project items across one or more statuses, sorted by the order of `statuses`."""
     project_data = query_project(owner, project_number)
     all_items = items_by_status(project_data, status_filter=None)
     wanted = set(statuses)
@@ -85,10 +79,8 @@ def main():
     parser = argparse.ArgumentParser(description="Query and update GitHub Project items")
     parser.add_argument("--owner",          default=_OWNER)
     parser.add_argument("--project-number", type=int, default=_PROJECT_NUMBER)
-    parser.add_argument("--status",         default=None,
-                        help="Single status filter (legacy). Defaults to Ready when neither flag is set.")
-    parser.add_argument("--include-statuses", default=None,
-                        help="Comma-separated statuses in display priority order. Overrides --status.")
+    parser.add_argument("--statuses",       default="Ready",
+                        help="Comma-separated statuses in display priority order")
     parser.add_argument("--json",           action="store_true")
     parser.add_argument("--set-status",     nargs=2, metavar=("ITEM_ID", "STATUS"))
     args = parser.parse_args()
@@ -97,8 +89,8 @@ def main():
         update_status(args.set_status[0], args.set_status[1],
                       owner=args.owner, project_number=args.project_number)
     else:
-        statuses = [s.strip() for s in args.include_statuses.split(",")] if args.include_statuses else None
-        list_items(status=args.status, statuses=statuses, json_output=args.json,
+        statuses = [s.strip() for s in args.statuses.split(",")]
+        list_items(statuses=statuses, json_output=args.json,
                    owner=args.owner, project_number=args.project_number)
 
 


### PR DESCRIPTION
Every task now starts on its own dedicated branch off the latest origin/main, detects existing in-flight branches by their -I<N> suffix to support clean resume, and surfaces a 4-option prompt when uncommitted work would otherwise be lost. Code-bearing tasks automatically enter plan mode with a context kickoff that includes the issue link, branch state, recap, and comments. The work-flow loop now leaves completed issues in a new Verify status (instead of closing them) so the human always reviews before close. Adding the Verify status column to the active project board is a one-time manual prerequisite.