### PR TITLE
Serialize GitHub API calls and extend label vocabulary

### DIFF
--- a/git-tools/lib/github_client.py
+++ b/git-tools/lib/github_client.py
@@ -8,14 +8,35 @@ Token resolution order:
   2. System keyring (GNOME Keyring / SecretService)
   3. gh CLI managed token (local dev fallback)
 """
+import fcntl
 import json
 import os
 import subprocess
 import sys
+from contextlib import contextmanager
 from pathlib import Path
 
 import keyring
 import requests
+
+_LOCK_PATH = "/tmp/.gh-api.lock"
+
+
+@contextmanager
+def _api_lock():
+    """Serialize concurrent GitHub API calls across processes via flock.
+
+    Multiple scripts (or parallel tool invocations) hitting api.github.com at the
+    same moment race on DNS resolution and can pile up against rate limits. A
+    single flock-protected critical section turns those concurrent calls into a
+    queue, making each call deterministic without needing retry logic.
+    """
+    with open(_LOCK_PATH, "w") as f:
+        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
 
 _CONFIG_PATH = Path(__file__).parent.parent.parent / "resources" / ".config"
 
@@ -103,12 +124,13 @@ def _check_graphql_errors(errors):
 
 def graphql(query, variables=None):
     """Execute a GraphQL query or mutation. Returns the full response dict."""
-    resp = requests.post(
-        GRAPHQL_URL,
-        headers={**_headers(), "Content-Type": "application/json"},
-        json={"query": query, "variables": variables or {}},
-        timeout=30,
-    )
+    with _api_lock():
+        resp = requests.post(
+            GRAPHQL_URL,
+            headers={**_headers(), "Content-Type": "application/json"},
+            json={"query": query, "variables": variables or {}},
+            timeout=30,
+        )
     _check_http(resp)
     data = resp.json()
     if "errors" in data:
@@ -118,19 +140,21 @@ def graphql(query, variables=None):
 
 def rest(method, path, **kwargs):
     """Make a GitHub REST API call. Returns parsed JSON (or {} for 204 No Content)."""
-    resp = requests.request(
-        method,
-        f"{REST_BASE}{path}",
-        headers=_headers(),
-        timeout=30,
-        **kwargs,
-    )
+    with _api_lock():
+        resp = requests.request(
+            method,
+            f"{REST_BASE}{path}",
+            headers=_headers(),
+            timeout=30,
+            **kwargs,
+        )
     _check_http(resp)
     return {} if resp.status_code == 204 else resp.json()
 
 
 def token_scopes():
     """Return the X-OAuth-Scopes header value, or '' for fine-grained PATs."""
-    resp = requests.get(f"{REST_BASE}/user", headers=_headers(), timeout=10)
+    with _api_lock():
+        resp = requests.get(f"{REST_BASE}/user", headers=_headers(), timeout=10)
     _check_http(resp)
     return resp.headers.get("X-OAuth-Scopes", "")

--- a/git-tools/scripts/init_labels.py
+++ b/git-tools/scripts/init_labels.py
@@ -14,6 +14,7 @@ import subprocess
 import sys
 
 STANDARD_LABELS = [
+    # PR review-effort vocabulary (used by /review and /ultrareview)
     {"name": "Trivial",       "color": "2ecc71", "description": "Can be evaluated quickly"},
     {"name": "Non-Trivial",   "color": "f1c40f", "description": "Needs a scan through, but is largely harmless"},
     {"name": "Complex",       "color": "e74c3c", "description": "Requires focused review, a step above Non-Trivial"},
@@ -24,6 +25,13 @@ STANDARD_LABELS = [
     {"name": "Enhancement",   "color": "a2eeef", "description": "New feature or request"},
     {"name": "Duplicate",     "color": "cfd3d7", "description": "This issue or pull request already exists"},
     {"name": "As Designed",   "color": "ffffff", "description": "Intended behavior, not a bug"},
+    # Issue-routing vocabulary (used by /todo and /git-plan)
+    {"name": "Code",          "color": "1d76db", "description": "Writing new feature code"},
+    {"name": "Defect",        "color": "d73a4a", "description": "Fixing broken or incorrect behavior"},
+    {"name": "Discovery",     "color": "5319e7", "description": "Investigation or research needed before work can start"},
+    {"name": "Inquiry",       "color": "fbca04", "description": "Open design question that must be resolved first"},
+    {"name": "DevOps",        "color": "006b75", "description": "Infrastructure, deployment, CI/CD, or automation work"},
+    {"name": "Epic",          "color": "9e0142", "description": "Top-level work group (managed by /git-plan)"},
 ]
 
 STANDARD_NAMES = {l["name"].lower() for l in STANDARD_LABELS}


### PR DESCRIPTION
`github_client.py` now serializes every `requests.*` call (REST + GraphQL + token-scopes) under a `flock` on `/tmp/.gh-api.lock`. Concurrent script invocations or parallel tool calls that race on `api.github.com` DNS resolution and rate limits queue deterministically through a single critical section, eliminating the transient DNS failures and 429 pile-ups that previously surfaced as tool errors when multiple `gh`-API scripts ran in parallel. The lock acquires only for the network call itself; response parsing and error handling stay outside the critical section to keep the lock-hold time minimal.

`init_labels.py` extends `STANDARD_LABELS` with the issue-routing vocabulary used by `/todo` and `/git-plan` (`Code`, `Defect`, `Discovery`, `Inquiry`, `DevOps`, `Epic`). Running `init_labels.py --repo <new-repo>` now provisions the full workspace label set in one shot — previously the issue-routing labels emitted by `/todo` would silently drop on any new repo because the PR-review labels were the only ones installed.