### PR TITLE
Force fresh queue read in /new-task and /work-flow loop

### DIFF
--- a/claude/commands/new-task.md
+++ b/claude/commands/new-task.md
@@ -4,6 +4,14 @@ Pick the next task to work on, create its branch, and (for code tasks) enter pla
 
 ## Step 1 — Build the unified task list
 
+**Always re-run this command at the start of every invocation. Never reuse JSON from a previous run, even within the same session.** Project board state can change between iterations from sources outside the current loop:
+- The user may have closed an issue manually or moved its column
+- A merged PR may have auto-closed the issue it `Closes`'d
+- A previous `/work-flow` iteration may have moved an item to Verify or Done
+- A `/todo` invocation may have added new Ready items
+
+When invoked from `/work-flow`'s loop, treat each iteration as a brand-new state read — do not render the menu from in-context memory of a prior iteration's `ready_items.py` output.
+
 ```bash
 python3 $HOME/git-workspace/claude-workspace/Claude-Project-Tooling/git-tools/interface/ready_items.py --include-statuses="Verify,In Progress,Ready"
 ```

--- a/claude/commands/work-flow.md
+++ b/claude/commands/work-flow.md
@@ -16,10 +16,12 @@ Report any items just promoted. Then enter the loop.
 
 Repeat steps 1–7 until the queue is empty. **Do not stop between iterations** — after moving an issue to Verify, immediately return to step 1 without waiting for user instruction.
 
+**Each iteration MUST re-fetch fresh project state via `ready_items.py`.** Never render the next iteration's menu from the previous iteration's data — the user may have closed an issue, moved a card, or merged a PR (auto-closing its issue) between iterations. Stale menus that show items in the wrong column (e.g., still showing a closed issue as Verify) are the most common loop bug. Treat in-context memory of a prior iteration's queue as untrusted.
+
 ### Steps 1–6 — Delegate to /new-task
 
 Run the full `/new-task` flow for each iteration. This handles, in order:
-- Building the unified Verify/In Progress/Ready list (with link emojis and color-coded status chips)
+- Building the unified Verify/In Progress/Ready list (with link emojis and color-coded status chips) — **always from a fresh `ready_items.py` read, never from cached data**
 - Selecting an item
 - Inferring the target repo
 - Resume detection (existing branch with `-I<N>` suffix)


### PR DESCRIPTION
The agent re-reads `ready_items.py` at the start of every `/new-task` invocation and every `/work-flow` loop iteration, never reusing JSON from a previous run within the same session. Stale menus that show items in the wrong column — typically a closed issue still rendered as Verify — are the most common loop bug, surfacing when the user closes an issue, merges a PR (auto-closing its issue), or runs another work-flow iteration between renders. The freshness rule is added to `/new-task` Step 1 (so it applies to direct invocations too) and to `/work-flow`'s Loop section, with the loop wording explicitly warning that in-context memory of the prior iteration's queue is untrusted.