### PR TITLE
Route /todo issues through trackers with auto Service tags

### DIFF
--- a/claude/skills/todo/SKILL.md
+++ b/claude/skills/todo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: todo
-description: Create a GitHub issue from free-form text. Discovers issue-enabled repos in the workspace, suggests the top three by relevance, then generates a short title, description, and appropriate labels before opening the issue.
+description: Create a GitHub issue from free-form text. Routes the issue to the correct tracker repo (some workspace repos delegate their issues to a central tracker), then generates a short title, description, and appropriate labels before opening it.
 ---
 
 Create a GitHub issue from the text passed as the skill argument.
@@ -9,9 +9,22 @@ Create a GitHub issue from the text passed as the skill argument.
 
 The skill argument is the raw text the user typed after /todo. Use it to understand the intent.
 
-## Step 2 — Pick the target repo
+## Step 2 — Pick the target tracker
 
-The repo set is discovered, not hardcoded. As new repos join the workspace they appear here automatically — no skill edit needed.
+Issues are filed in **tracker repos** — repos whose Issues tab actually accepts and tracks issues. Other workspace repos are **delegates**: their source code lives there, but their issues are tracked elsewhere. The picker presents only tracker repos.
+
+### Workspace tracker map
+
+This table is the source of truth for which repo accepts issues for each domain. When new repos join the workspace, add a row.
+
+| Workspace repo | Acts as | Tracker | Auto Service tag |
+|----------------|---------|---------|------------------|
+| `AndresI19/RS-Agent-Planning` | tracker (self) | `AndresI19/RS-Agent-Planning` | — |
+| `AndresI19/rs-mcp-server` | delegate | `AndresI19/RS-Agent-Planning` | `Service: MCP` |
+| `AndresI19/Claude-Project-Tooling` | tracker (self) | `AndresI19/Claude-Project-Tooling` | — |
+| (future RS-* code repo) | delegate | `AndresI19/RS-Agent-Planning` | `Service: <name>` |
+
+**Why some repos delegate**: `RS-Agent-Planning` is the centralized issue tracker and project board for the entire RuneScape project. RS-* code repos (`rs-mcp-server` today; potentially a Discord bot, voice service, etc. in the future) all funnel their issues there with `Service: <name>` labels distinguishing which code repo each issue targets. `Claude-Project-Tooling` is general workspace tooling — not part of the RuneScape project — so it tracks its own issues.
 
 ### Discover candidates
 
@@ -19,22 +32,24 @@ The repo set is discovered, not hardcoded. As new repos join the workspace they 
 gh repo list AndresI19 --json name,nameWithOwner,description,hasIssuesEnabled --limit 100
 ```
 
-Filter the result to repos that:
-1. Have `hasIssuesEnabled: true`, AND
-2. Have a matching directory under `$HOME/git-workspace/claude-workspace/` (so archived or unrelated repos in the account don't get suggested):
+Filter the result to repos that are:
+1. `hasIssuesEnabled: true`, AND
+2. Present as a directory under `$HOME/git-workspace/claude-workspace/`:
    ```bash
    ls $HOME/git-workspace/claude-workspace
    ```
+3. Listed as a **tracker** (`Acts as: tracker`) in the table above. Delegate repos are NOT eligible candidates — their issues route through their tracker.
 
-### Rank top 3
+### Determine the implied delegate (if any)
 
-Score each candidate against the issue text. Combine these signals:
-- **Lexical match**: issue keywords against the repo's name and description
-- **Domain hints** (extend as new repos appear):
-  - tooling, skills, scripts, claude config, workspace infrastructure, hooks, cron, /pr, /todo, /new-task, /work-flow, /review → favor `Claude-Project-Tooling`
-  - planning, agents, architecture, MCP server, tools (search_wiki / get_item_price / get_player_stats / get_quest_info), wiki, hiscores, GE → favor `RS-Agent-Planning`
+Inspect the issue text to identify which workspace component it concerns:
+- If the issue is about an **RS-* code repo's domain** (e.g., MCP server tools, hiscores tooling, future Discord bot, etc.) → that delegate's tracker (`RS-Agent-Planning`) is the correct destination, AND the delegate's `Auto Service tag` should be applied automatically.
+- If the issue is about **workspace tooling** (skills, scripts, hooks, /pr, /todo, /new-task, /work-flow, /review, etc.) → `Claude-Project-Tooling`'s self-tracker is the destination. No Service tag.
+- If the issue is about **planning, agent architecture, or project-level concerns** that aren't tied to a specific RS code repo → `RS-Agent-Planning` directly. No Service tag.
 
-The single top-ranked candidate is the **Recommended** choice. Take the next two highest-ranked candidates as the alternates. If fewer than 3 candidates exist, present whatever you have (minimum 2 required by `AskUserQuestion`).
+### Rank top 3 trackers
+
+Apply the domain hints above to rank the discovered tracker repos. The single top-ranked is the **Recommended** choice. Take the next two highest-ranked as alternates. With only two tracker repos in the workspace today, present 2 options (the auto-Other escape covers any third destination).
 
 ### Present the choice
 
@@ -42,22 +57,23 @@ Call the `AskUserQuestion` tool with one question:
 - `question`: "Which repo should this issue go to?"
 - `header`: "Repo"
 - `multiSelect`: false
-- `options`: up to 3 entries. Each entry's `label` is the repo `nameWithOwner` (suffix " (Recommended)" on the highest-ranked one, per the tool's convention). Each entry's `description` is a one-sentence rationale for why this repo fits.
+- `options`: up to 3 tracker repos. Each entry's `label` is the tracker's `nameWithOwner` (suffix " (Recommended)" on the highest-ranked). Each entry's `description` explains what kinds of issues that tracker accepts and, if relevant, which delegate code repos route to it.
 
-The tool automatically appends an **Other** escape — selecting it lets the user type any `owner/repo` value (or cancel via escape).
+The tool automatically appends an **Other** escape — the user can type any `<owner>/<repo>` (validated against `gh repo view`) or cancel.
 
-### Resolve `TARGETREPO`
+### Resolve `TARGETREPO` and `SERVICE_TAG`
 
-- Selected one of the presented options → use its `nameWithOwner` as `TARGETREPO`.
-- Selected Other and typed a value → validate it matches `<owner>/<repo>` shape AND that `gh repo view <owner/repo>` succeeds. If validation fails, show the error and re-prompt.
-- Cancelled → exit the skill silently.
+- `TARGETREPO` = the chosen tracker's `nameWithOwner`
+- `SERVICE_TAG` = the auto Service tag from the table, IF the issue's subject is about a delegate that routes to `TARGETREPO`. Otherwise empty.
+
+If the user picks **Other** and types a delegate code repo by mistake (e.g., `AndresI19/rs-mcp-server`), redirect: replace `TARGETREPO` with the delegate's tracker from the table, set `SERVICE_TAG` to the delegate's auto Service tag, and tell the user "filing in `<tracker>` with `<service tag>` since `<delegate>` delegates its issues there."
 
 ## Step 3 — Generate title, description, and labels
 
 From the input text, derive:
 - **Title**: short, imperative, max 6 words (e.g. "Add retry logic to pr skill", "Fix token usage parsing")
 - **Description**: 1-3 sentences expanding on the intent. Be concise. No bullet lists. Do not speculate on root cause or solutions — describe only the observed problem or desired outcome.
-- **Labels**: pick all that apply from the standard vocabulary below. Most issues take 1-2 labels.
+- **Labels**: pick all that apply from the standard vocabulary below. Most issues take 1-2 labels. **If `SERVICE_TAG` is set from Step 2, include it automatically** in addition to whichever universal labels apply.
 
 ### Label vocabulary
 
@@ -68,10 +84,10 @@ From the input text, derive:
 | `Discovery` | Investigation or research needed before work can start |
 | `Inquiry` | Open design question that must be resolved first |
 | `DevOps` | Infrastructure, deployment, CI/CD, or automation work |
-| `Service: <name>` | Changes specific to a named service (e.g. `Service: MCP`). Project-specific — only present on repos that defined them. |
+| `Service: <name>` | Changes specific to a named delegate repo (e.g. `Service: MCP`). Auto-applied by Step 2 when the issue routes through a tracker on behalf of a delegate. |
 | `Epic` | Do not use — reserved for git-plan |
 
-The universal labels above (`Code`, `Defect`, `Discovery`, `Inquiry`, `DevOps`, `Epic`) are installed on every repo by `init_labels.py`. Service-specific tags are project-local and may not exist on the target repo — if uncertain, omit them and let the issue be re-tagged later.
+The universal labels (`Code`, `Defect`, `Discovery`, `Inquiry`, `DevOps`, `Epic`) are installed on every repo by `init_labels.py`. Service-specific tags are project-local and may not exist on every tracker — they're created by `init_labels.py` per-project as needed.
 
 ## Step 4 — Create the issue
 
@@ -86,27 +102,27 @@ python3 $HOME/git-workspace/claude-workspace/Claude-Project-Tooling/git-tools/in
   [--project]
 ```
 
-`TARGETREPO` is the full `owner/repo` from Step 2.
+`TARGETREPO` is the full `owner/repo` from Step 2. Include `SERVICE_TAG` (if set) as one of the `--label` flags.
 
 ### `--project` flag
 
-Include `--project` when `TARGETREPO` has an active GitHub Project board. Project-bearing repos in the workspace today:
+Include `--project` when `TARGETREPO` has an active GitHub Project board. Project-bearing trackers in the workspace today:
 
-| Repo | Project |
-|------|---------|
+| Tracker | Project |
+|---------|---------|
 | `AndresI19/RS-Agent-Planning` | Build RuneScape MCP Server |
 
-When new project-bearing repos appear, add them to this table.
+When new project-bearing trackers appear, add them to this table.
 
-For repos without a project board (e.g. `AndresI19/Claude-Project-Tooling` today), omit `--project`.
+For trackers without a project board (e.g. `AndresI19/Claude-Project-Tooling` today), omit `--project`.
 
 When `--project` is used, the script prints `ITEM_ID: <id>` followed by the issue URL. **Capture both.**
 
-## Step 5 — Set initial project status (project-bearing repos only)
+## Step 5 — Set initial project status (project-bearing trackers only)
 
-Skip this step entirely for repos without a project board.
+Skip this step entirely for trackers without a project board.
 
-For project-bearing repos, decide between **Todo** (queued, blocked by other work) and **Ready** (can be picked up immediately) by inferring sequential dependencies from existing project items.
+For project-bearing trackers, decide between **Todo** (queued, blocked by other work) and **Ready** (can be picked up immediately) by inferring sequential dependencies from existing project items.
 
 Fetch all current open project items:
 


### PR DESCRIPTION
The `/todo` skill now distinguishes **tracker repos** (which accept their own issues) from **delegate repos** (whose issues route through a tracker). The picker presents only trackers, so RS-* code repos like `rs-mcp-server` no longer surface as candidates — their issues route automatically to `RS-Agent-Planning` with the appropriate `Service: <name>` label, matching the workspace's two-domain layout where the planning repo centralizes RuneScape-project tracking and `Claude-Project-Tooling` tracks workspace tooling separately. If a user types a delegate via the Other escape by mistake, Step 2 redirects to the delegate's tracker and explains the routing inline. Adding a future delegate is two rows in the tracker map; no flow-logic changes are needed.