### PR TITLE
Run pytest suite on every PR via GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest requests keyring GitPython
+
+      - name: Run pytest
+        working-directory: git-tools
+        run: pytest tests/ -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-          cache: pip
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Adds a GitHub Actions workflow that installs pytest plus the runtime dependencies the library and scripts already use (`requests`, `keyring`, `GitPython`) and runs the existing 84-test suite in `git-tools/tests/` on every pull request and every push to `main`. The tests are pure unit tests with mocked GitHub API calls, so the workflow needs no secrets and stays fast (under five seconds locally). Once this lands, the `tests` check can be added to the branch protection ruleset to gate merges on a green suite and to enable the "Require branches to be up to date before merging" requirement.