### PR TITLE
Patch /record to push Planning/ edits

### DIFF
--- a/claude/skills/record/SKILL.md
+++ b/claude/skills/record/SKILL.md
@@ -31,6 +31,25 @@ Do **not** proceed with the session log until the user confirms how to handle it
 
 ---
 
+## Pre-flight — Check for Planning/ changes
+
+Run:
+```bash
+git -C ~/git-workspace/claude-workspace/RS-Agent-Planning status --short -- Planning/
+```
+
+If there are **any uncommitted or unstaged changes** under `Planning/` (typically /work-flow Inquiry/Discovery deliverables), prompt the user:
+
+> The Planning/ directory in RS-Agent-Planning has uncommitted edits. Include them in this push? (y/N)
+
+If **yes** → set `INCLUDE_PLANNING=1` and pass `--include-planning` to `push_sessions.py` in the FINALIZE step. The Planning/ edits will commit alongside the session log under the same commit message.
+
+If **no** → proceed without the flag; Planning/ edits remain dirty in the working tree for a future push.
+
+If the directory is clean, skip silently.
+
+---
+
 ## Step 1 — Determine action
 
 ```bash
@@ -106,7 +125,9 @@ Replace the session table rows and totals in
 and update the "Last updated" date. The script outputs one `| row |` per session file followed by a `TOTALS` line.
 
 ```bash
-python3 $HOME/git-workspace/claude-workspace/Claude-Project-Tooling/git-tools/scripts/push_sessions.py --message "MESSAGE"
+python3 $HOME/git-workspace/claude-workspace/Claude-Project-Tooling/git-tools/scripts/push_sessions.py --message "MESSAGE" [--include-planning]
 ```
 
-Use a short descriptive commit message (e.g. "Update Claude Sessions and token usage"). The script only stages and pushes files under `Claude Sessions/` in RS-Agent-Planning. Claude-Project-Tooling is never touched — script changes there must go through `/pr`.
+Use a short descriptive commit message (e.g. "Update Claude Sessions and token usage", or "Record session + add game-disambiguation decision (#45)" when bundling a Planning edit).
+
+The script stages and pushes files under `Claude Sessions/` in RS-Agent-Planning. With `--include-planning` (set when the Planning pre-flight got a yes) it also stages files under `Planning/`. Claude-Project-Tooling is never touched — script changes there must go through `/pr`.

--- a/git-tools/scripts/push_sessions.py
+++ b/git-tools/scripts/push_sessions.py
@@ -2,14 +2,18 @@
 """
 push_sessions.py — Commit and push RS-Agent-Planning session logs to origin/main.
 
-Only stages files under 'Claude Sessions/' — script and tooling changes in
-Claude-Project-Tooling must go through a PR via the /pr skill instead.
+Stages files under 'Claude Sessions/' by default. With --include-planning, also
+stages files under 'Planning/' so /work-flow Inquiry/Discovery doc edits ride
+along with the next /record push (the documented behavior of /work-flow). Script
+and tooling changes in Claude-Project-Tooling must still go through a PR via the
+/pr skill instead.
 
 If the current branch is not main, the script switches to main first (carrying
-uncommitted session log edits with it), commits, pushes, then switches back.
+uncommitted edits with it), commits, pushes, then switches back.
 
 Usage:
     python3 push_sessions.py --message "Update Claude Sessions and token usage"
+    python3 push_sessions.py --message "Record session + planning decision" --include-planning
 """
 
 import argparse
@@ -21,17 +25,30 @@ from git.exc import GitCommandError
 
 SESSION_REPO_PATH = Path.home() / "git-workspace/claude-workspace/RS-Agent-Planning"
 SESSION_DIR       = "Claude Sessions"
+PLANNING_DIR      = "Planning"
+
+
+def _stage_dir(repo, subdir):
+    """Stage every file under <repo>/<subdir>/ in the index. No-op if missing."""
+    path = SESSION_REPO_PATH / subdir
+    if not path.exists():
+        return
+    files = [
+        str(f.relative_to(SESSION_REPO_PATH))
+        for f in path.rglob("*") if f.is_file()
+    ]
+    if files:
+        repo.index.add(files)
 
 
 def stage_session_files(repo):
     """Stage all files under Claude Sessions/ in the index."""
-    session_path = SESSION_REPO_PATH / SESSION_DIR
-    files = [
-        str(f.relative_to(SESSION_REPO_PATH))
-        for f in session_path.rglob("*") if f.is_file()
-    ]
-    if files:
-        repo.index.add(files)
+    _stage_dir(repo, SESSION_DIR)
+
+
+def stage_planning_files(repo):
+    """Stage all files under Planning/ in the index."""
+    _stage_dir(repo, PLANNING_DIR)
 
 
 def has_staged(repo):
@@ -45,6 +62,11 @@ def has_staged(repo):
 def main():
     parser = argparse.ArgumentParser(description="Push session logs to origin/main")
     parser.add_argument("--message", required=True, help="Commit message")
+    parser.add_argument(
+        "--include-planning",
+        action="store_true",
+        help="Also stage Planning/ edits in addition to Claude Sessions/.",
+    )
     args = parser.parse_args()
 
     repo = Repo(SESSION_REPO_PATH)
@@ -75,8 +97,10 @@ def main():
             sys.exit(1)
         switched = True
 
-    # ── Stage only session log files ──────────────────────────────────────────
+    # ── Stage selected paths ──────────────────────────────────────────────────
     stage_session_files(repo)
+    if args.include_planning:
+        stage_planning_files(repo)
 
     if not has_staged(repo):
         print(f"  {name}: nothing to commit — skipped")


### PR DESCRIPTION
The /work-flow skill documents Inquiry/Discovery doc edits as riding along with the next /record push, but push_sessions.py only stages Claude Sessions/, leaving Planning/ edits stranded. Adding an --include-planning flag to push_sessions.py and a Planning/ pre-flight to the /record skill closes the gap so Planning edits can ride alongside the session log under one commit when the user opts in. The flag is opt-in via a y/N prompt rather than always-on so unrelated dirty Planning state does not get swept up by surprise. Surfaced while trying to push a game-disambiguation decision recorded for AndresI19/RS-Agent-Planning#45.