### PR TITLE
Add /triage skill and project selector

### DIFF
--- a/claude/commands/git-plan.md
+++ b/claude/commands/git-plan.md
@@ -1,24 +1,80 @@
 # /git-plan
 
-Generate a top-down GitHub project plan, then create it in GitHub upon approval.
+Operate on a GitHub project: pick an existing one to triage or extend, or create a new one from scratch.
 
-## Pre-flight — Check for an active project
+## Pre-flight — Project selector
 
-**Before doing anything else**, run:
+**Before doing anything else**, render the selector menu:
 
 ```bash
-python3 Claude-Project-Tooling/git-tools/interface/loop_state.py
+python3 Claude-Project-Tooling/git-tools/interface/list_projects.py
 ```
 
-`loop_state.py` returns JSON with `next_action`:
+The script prints a numbered list of every existing project (oldest first, with the oldest active project highlighted as `/work-flow default`) plus a `0. + Create new project` row.
 
-- `"continue"` — Ready or In Progress items exist. Stop and report; the project is still active.
-- `"blocked"` — Todo/Backlog items remain but all blockers are still open. Stop; issues must be resolved first.
-- `"plan"` — all queues empty. Proceed to Phase 1.
+Play `user-select.wav` and prompt: "Pick? (number, or 0 to cancel)".
+
+- **User picks 1..N** → the chosen project becomes `PROJECT`. Proceed to **Branch A: operate on existing project**.
+- **User picks 0** → proceed to **Branch B: create new project**.
+- **User cancels** → exit cleanly.
 
 ---
 
-## Hierarchy
+## Branch A — Operate on existing project
+
+Show the chosen project's status counts (already returned by `list_projects.py --json`), then sub-prompt:
+
+> "What do you want to do with `<Project title>`?
+>   1. Triage — review proposed status moves
+>   2. Extend — add new Epics or Issues
+>   3. Both — triage first, then extend
+>   0. Cancel"
+
+Play `user-select.wav` before the prompt.
+
+### Branch A.1 — Triage
+
+Invoke the `/triage` skill against the selected project. Skip its Step 1 (project already chosen) and start at Step 2 — pull all open items, reason about each, render the proposal table, get authorization, apply.
+
+### Branch A.2 — Extend
+
+Run a **modified Phase 1/2** that adds new Epics/Issues to the existing project without touching anything that already exists.
+
+#### Phase 1 (extend) — Plan additions only
+
+Call `EnterPlanMode` immediately. Then:
+
+1. **Gather context.** Read `RS-Agent-Planning/Planning/project-overview.md`, `architecture.md`, and `tasks.md`. List the existing project's open items (from the JSON output of `list_projects.py`) so the new plan complements rather than duplicates them.
+
+2. **Draft additions only.** Propose new Epics and/or new Issues that fit into the existing project. Do NOT re-list items that already exist.
+
+3. **Write the plan** to the plan file in the same format as Branch B (see "Plan File Format" below), but only the new content.
+
+4. **Iterate.** Adjust based on feedback.
+
+5. Call `ExitPlanMode` to present the plan for final approval.
+
+#### Phase 2 (extend) — Execute
+
+Serialize the approved additions into the same JSON schema as Branch B, with `project_title` set to **the existing project's exact title**:
+
+```bash
+python3 Claude-Project-Tooling/git-tools/scripts/git-plan.py --meta '<JSON>'
+```
+
+`git-plan.py` is idempotent for existing items — it creates new Epics/Issues, links child issue numbers into Epic checklists, and **only sets status on newly created issues**. Existing items are never overwritten on re-runs. That property is what makes "extend" safe.
+
+### Branch A.3 — Both
+
+Run Branch A.1 (triage) first. After moves are applied, ask if the user wants to extend; if yes, run Branch A.2.
+
+---
+
+## Branch B — Create new project
+
+This is the original `/git-plan` create-from-scratch flow. The Phase 1/2 logic below is unchanged.
+
+### Hierarchy
 
 | Level | GitHub object | Scope |
 |-------|--------------|-------|
@@ -28,7 +84,7 @@ python3 Claude-Project-Tooling/git-tools/interface/loop_state.py
 
 **All planning issues, epics, and projects are created in `AndresI19/RS-Agent-Planning`.**
 
-## Phase 1 — Plan (read-only)
+### Phase 1 — Plan (read-only)
 
 Call `EnterPlanMode` immediately before doing anything else.
 
@@ -76,7 +132,7 @@ Then:
 - Multiple blockers are comma-separated
 - Use `none` when there are no blockers
 
-## Phase 2 — Execute (after ExitPlanMode approval)
+### Phase 2 — Execute (after ExitPlanMode approval)
 
 Serialize the approved plan into the JSON schema below and run:
 
@@ -125,6 +181,8 @@ The script:
 3. Links child issue numbers back into each Epic's checklist body
 4. Adds everything to the project board with the correct initial status
 5. **Only sets status on newly created issues** — existing items are never overwritten on re-runs
+
+---
 
 ## Label Guidelines
 

--- a/claude/commands/new-task.md
+++ b/claude/commands/new-task.md
@@ -20,10 +20,18 @@ Parse the JSON. Each item has: `item_id`, `number`, `title`, `labels`, `url`, `s
 
 **Render the menu as markdown in your text response — not via Bash printf.** Bash outputs over a few lines get auto-folded and the user has to expand them; markdown in your text response is always visible and supports hyperlinks.
 
-Status is conveyed by an **emoji indicator** at the start of each row (no color column, no padding):
-- `Verify` → 🟡
-- `In Progress` → 🔵
-- `Ready` → ⚪
+Status is conveyed by an **emoji indicator** at the start of each row (no color column, no padding). The canonical map lives in `git-tools/lib/status_emojis.py` — keep it in sync with anything you render here:
+
+| Status | Emoji |
+|--------|-------|
+| Backlog | ⚫ |
+| Todo | 🟠 |
+| Ready | ⚪ |
+| In Progress | 🔵 |
+| Verify | 🟡 |
+| Done | 🟢 |
+
+`/new-task`'s menu only filters to `Verify`, `In Progress`, and `Ready`, so the rendered rows will only ever use 🟡, 🔵, and ⚪. The full lifecycle is documented above for reference.
 
 The issue number is the link, rendered as a markdown hyperlink at the end of the line.
 

--- a/claude/skills/triage/SKILL.md
+++ b/claude/skills/triage/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: triage
+description: Project-wide issue triage. Pulls every open item in a GitHub Project, reasons about each one (dependencies, observable PR state, staleness, label intent), proposes status moves with explanations, and applies them as a batch after explicit user authorization. Use when project board statuses have drifted, after a /git-plan creation pass, or when issues have closed externally and dependent items need to advance.
+---
+
+Triage a GitHub Project: read every open item, propose status moves with reasoning, present them as a table, get the user's approval, apply the batch.
+
+## Step 1 — Pick the project
+
+The skill argument (if any) is a free-form project name. Resolve it to a project number:
+
+- **No argument** → render the selector menu:
+  ```bash
+  python3 $HOME/git-workspace/claude-workspace/Claude-Project-Tooling/git-tools/interface/list_projects.py --no-create-new
+  ```
+  Play `user-select.wav` before prompting; ask "Pick? (number, or 0 to cancel)". The user picks.
+
+- **Argument provided** → load the project list as JSON:
+  ```bash
+  python3 $HOME/git-workspace/claude-workspace/Claude-Project-Tooling/git-tools/interface/list_projects.py --json
+  ```
+  Match the argument against project titles:
+  - **Exact (case-insensitive) match** → proceed with that project
+  - **Multiple plausible matches** (substring or fuzzy) → present a "Did you mean…" disambiguation prompt; do not silently substitute
+  - **No matches** → render the full selector menu
+
+Capture `PROJECT_NUMBER` and `OWNER` for the rest of the flow. `OWNER` comes from the workspace config; `PROJECT_NUMBER` is the user's selection.
+
+## Step 2 — Pull all items + their issue context
+
+Fetch every open item in the project:
+
+```bash
+python3 $HOME/git-workspace/claude-workspace/Claude-Project-Tooling/git-tools/interface/ready_items.py \
+  --include-statuses="Backlog,Todo,Ready,In Progress,Verify"
+```
+
+This returns a JSON array of items with `item_id`, `number`, `title`, `labels`, `url`, `status`. Done items aren't included — they don't need triage.
+
+For each item, fetch its body and recent comments:
+
+```bash
+python3 $HOME/git-workspace/claude-workspace/Claude-Project-Tooling/git-tools/interface/issue_context.py NUMBER --repo OWNER/REPO
+```
+
+Cache all context in-memory for the rest of the session. For a 20-item project, expect ~20 calls; that's the budget.
+
+## Step 3 — Reason per item
+
+For each open item, decide on a **proposed status**. Consider:
+
+- **Observable PR state** — Use `gh pr list --search "linked:NUMBER"` (or scan the issue body / comments for `Closes`, `Fixes`, `Resolves` clauses) to find linked PRs. If a `Closes` PR has merged, item should move to **Done**. If a PR is open and review is pending, **Verify** is appropriate.
+- **Mentioned blockers** — Issue bodies may still contain `## Blocked By` sections (the writer side wasn't removed). Treat them as a hint, not a rule. If all blockers have closed, the item can advance from Todo → Ready. If at least one blocker is still open, the item belongs in Todo (or Backlog if also low-priority).
+- **Labels** — Epic items never move; their child items advance instead. Discovery/Inquiry items can move Backlog → Ready when there's bandwidth and they aren't blocked. Defect items in the active queue typically take precedence over Backlog work.
+- **Comment activity** — A Verify item with no PR and no activity for 30+ days is a signal for either Done (forgotten close) or back to Ready (forgotten work). Read the body before guessing.
+- **Project shape** — If 5 items are already In Progress, don't propose moving more from Ready to In Progress. Surface workflow imbalance instead.
+
+For each item, produce a tuple:
+
+```
+(item_id, number, title, current_status, proposed_status, dependencies_summary, reasoning)
+```
+
+If `proposed_status == current_status`, the row is a "no change" row and renders muted in the table — but the user still sees it (transparency over brevity).
+
+## Step 4 — Render the proposal table
+
+Format the proposal as a markdown table. Use status emojis from the canonical map (see `git-tools/lib/status_emojis.py`):
+
+```
+Triage proposal — <Project Title> (N items, M changes proposed)
+
+| #   | Issue                        | Now           | →  | Proposed     | Dependencies        | Reasoning                                          |
+|-----|------------------------------|---------------|----|--------------|---------------------|----------------------------------------------------|
+| 1.  | #41 Add street prices …      | 🟡 Verify     | →  | 🟢 Done      | PR #33 merged       | PR merged 2 days ago; safe to close                |
+| 2.  | #21 Configure TLS and proxy  | ⚪ Ready      | →  | 🟠 Todo      | needs #20           | #20 not yet started; can't do TLS without host     |
+| 3.  | #46 Investigate RS LLM       | ⚪ Ready      | →  | ⚫ Backlog   | —                   | No active driver; defer until Phase 2 starts       |
+| 4.  | #29 Investigate Actions notif| 🟡 Verify     | →  | 🟢 Done      | PRs #48 & #61 merged| Both companion PRs merged                          |
+| 5.  | #19 Validate cache TTL       | ⚪ Ready      |    | (no change)  | —                   | Already in correct state                           |
+| …   | (other no-change rows)       |               |    |              |                     |                                                    |
+
+Legend: ⚫ Backlog · 🟠 Todo · ⚪ Ready · 🔵 In Progress · 🟡 Verify · 🟢 Done
+
+Apply all M changes? (y / e / n)
+  y = approve all
+  e = edit (specify rows to skip or override; see below)
+  n = cancel
+```
+
+Number the rows 1..N, including no-change rows, so the user can reference any row by its number when editing.
+
+## Step 5 — Authorization gate (with edits)
+
+Read the user's answer. Single-character `y`, `n`, or one or more `e` directives separated by commas or newlines:
+
+- **`y`** → proceed to Step 6 with the proposal as-is.
+- **`n`** → cancel. Print "Triage cancelled — no changes applied." and exit.
+- **`e <directives>`** → parse each directive:
+  - `skip <row>` — remove row's proposed change from the batch (turns into "no change")
+  - `<row> → <Status>` — override the proposed status for that row (e.g. `3 → Todo` keeps issue #46 as Todo instead of demoting to Backlog)
+  - `add <row> → <Status>` — promote a previously-no-change row into the batch with the given target status
+
+  After applying edits, re-render the table from Step 4 with overrides and re-prompt. Loop until `y` or `n`.
+
+Status names in directives match the canonical names: Backlog, Todo, Ready, In Progress, Verify, Done.
+
+Play `user-select.wav` before each prompt so the user knows it's their turn.
+
+## Step 6 — Apply the batch
+
+Build a JSON array of approved moves and pipe to the batch endpoint:
+
+```bash
+echo '[{"item_id":"PVTI_…","status":"Done"},{"item_id":"PVTI_…","status":"Backlog"}]' | \
+python3 $HOME/git-workspace/claude-workspace/Claude-Project-Tooling/git-tools/interface/set_statuses.py
+```
+
+The script applies all mutations in a single GraphQL request and prints `✓ N status mutation(s) applied.`
+
+If the call fails, surface the error to the user — the underlying call is atomic per-item server-side, so partial application is rare but possible. On failure, list which items succeeded vs. failed (parse from the GraphQL response if needed).
+
+## Step 7 — Report
+
+Print a one-line confirmation with the project name, count of moves applied, and a link back to the project board so the user can verify. Done.
+
+---
+
+## Notes for `/git-plan` Branch A integration
+
+When invoked from `/git-plan`'s "operate on existing project" sub-flow, skip Step 1 (the project is already chosen) and start at Step 2.

--- a/claude/skills/triage/SKILL.md
+++ b/claude/skills/triage/SKILL.md
@@ -91,20 +91,24 @@ Number the rows 1..N, including no-change rows, so the user can reference any ro
 
 ## Step 5 — Authorization gate (with edits)
 
-Read the user's answer. Single-character `y`, `n`, or one or more `e` directives separated by commas or newlines:
+Play `user-select.wav` before the prompt, then call `AskUserQuestion` with one question:
 
-- **`y`** → proceed to Step 6 with the proposal as-is.
-- **`n`** → cancel. Print "Triage cancelled — no changes applied." and exit.
-- **`e <directives>`** → parse each directive:
-  - `skip <row>` — remove row's proposed change from the batch (turns into "no change")
-  - `<row> → <Status>` — override the proposed status for that row (e.g. `3 → Todo` keeps issue #46 as Todo instead of demoting to Backlog)
-  - `add <row> → <Status>` — promote a previously-no-change row into the batch with the given target status
+- `question`: "Apply <N> proposed status change(s)?"
+- `header`: "Triage"
+- `multiSelect`: false
+- `options`:
+  - **Approve all** — proceed to Step 6 with the proposal as-is.
+  - **Propose change** — open a free-text follow-up prompt where the user lists edits.
+  - **Cancel** — abort. Print "Triage cancelled — no changes applied." and exit.
 
-  After applying edits, re-render the table from Step 4 with overrides and re-prompt. Loop until `y` or `n`.
+If the user picks **Propose change**, ask "What changes? (one per line)". Parse each line as a directive:
+- `skip <row>` — remove row's proposed change from the batch (turns into "no change")
+- `<row> → <Status>` — override the proposed status for that row (e.g. `3 → Todo` keeps issue #46 as Todo instead of demoting to Backlog)
+- `add <row> → <Status>` — promote a previously-no-change row into the batch with the given target status
+
+After applying edits, re-render the table from Step 4 with overrides and re-prompt with `AskUserQuestion` again. Loop until **Approve all** or **Cancel**.
 
 Status names in directives match the canonical names: Backlog, Todo, Ready, In Progress, Verify, Done.
-
-Play `user-select.wav` before each prompt so the user knows it's their turn.
 
 ## Step 6 — Apply the batch
 

--- a/git-tools/interface/list_projects.py
+++ b/git-tools/interface/list_projects.py
@@ -14,7 +14,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 sys.path.insert(0, str(Path(__file__).parent.parent / "lib"))
 from projects import list_all_projects, find_oldest_active
 from github_client import load_config
-from status_emojis import STATUS_EMOJI
+from status_emojis import STATUS_EMOJI, legend as status_legend
 
 # ANSI helpers (kept inline — display.py covers richer rendering but this
 # script is intentionally lightweight so /git-plan and /triage can both use it).
@@ -55,6 +55,8 @@ def render_menu(projects, oldest_number, include_create_new=True):
         lines.append("")
         lines.append(f"   0. {BOLD}+ Create new project{RESET}")
     lines.append("")
+    lines.append(f"Legend: {status_legend()}")
+    lines.append("")
     lines.append("Pick? (number, or 0 to cancel)")
     return "\n".join(lines)
 
@@ -64,12 +66,16 @@ def main():
     parser.add_argument("--json", action="store_true", help="emit JSON instead of a formatted menu")
     parser.add_argument("--no-create-new", action="store_true",
                         help="omit the '0. Create new project' row (used by /triage)")
+    parser.add_argument("--include-closed", action="store_true",
+                        help="include closed/archived projects in the output (hidden by default)")
     args = parser.parse_args()
 
     cfg = load_config()
     owner = cfg["owner"]
 
     projects = list_all_projects(owner)
+    if not args.include_closed:
+        projects = [p for p in projects if not p["closed"]]
     # Default sort: oldest first (matches the "oldest is /work-flow default" surface).
     projects.sort(key=lambda p: p["createdAt"])
 

--- a/git-tools/interface/list_projects.py
+++ b/git-tools/interface/list_projects.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""List every GitHub Project for the configured owner.
+
+Usage:
+    python3 list_projects.py             # formatted selector menu
+    python3 list_projects.py --json      # machine-readable JSON
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+sys.path.insert(0, str(Path(__file__).parent.parent / "lib"))
+from projects import list_all_projects, find_oldest_active
+from github_client import load_config
+from status_emojis import STATUS_EMOJI
+
+# ANSI helpers (kept inline — display.py covers richer rendering but this
+# script is intentionally lightweight so /git-plan and /triage can both use it).
+RESET   = "\033[0m"
+DIM     = "\033[2m"
+BOLD    = "\033[1m"
+DEFAULT = "\033[44m"   # blue background → /work-flow default row
+
+
+def _format_counts(counts):
+    """Render a status-counts dict like {'Ready': 5, 'In Progress': 2} as
+    '5 ⚪ · 2 🔵' in the same lifecycle order as STATUS_EMOJI."""
+    parts = []
+    for name, emoji in STATUS_EMOJI.items():
+        if counts.get(name):
+            parts.append(f"{counts[name]} {emoji}")
+    return " · ".join(parts) if parts else "(empty)"
+
+
+def render_menu(projects, oldest_number, include_create_new=True):
+    """Return a multi-line string of the selector menu."""
+    if not projects:
+        if include_create_new:
+            return "No projects yet. Pick `0` to create one.\n\n  0.  + Create new project\n"
+        return "No projects yet.\n"
+
+    width = max(len(p["title"]) for p in projects)
+    lines = ["Pick a project:\n"]
+    for i, p in enumerate(projects, start=1):
+        title  = p["title"].ljust(width)
+        counts = _format_counts(p["status_counts"])
+        date   = p["createdAt"][:10]   # YYYY-MM-DD
+        suffix = "  ← /work-flow default" if p["number"] == oldest_number else ""
+        prefix = DEFAULT if p["number"] == oldest_number else ""
+        body   = f"  {i:>2}. ⚪ {title}   {counts}   created {date}{suffix}"
+        lines.append(f"{prefix}{body}{RESET}" if prefix else body)
+    if include_create_new:
+        lines.append("")
+        lines.append(f"   0. {BOLD}+ Create new project{RESET}")
+    lines.append("")
+    lines.append("Pick? (number, or 0 to cancel)")
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List GitHub Projects for the configured owner")
+    parser.add_argument("--json", action="store_true", help="emit JSON instead of a formatted menu")
+    parser.add_argument("--no-create-new", action="store_true",
+                        help="omit the '0. Create new project' row (used by /triage)")
+    args = parser.parse_args()
+
+    cfg = load_config()
+    owner = cfg["owner"]
+
+    projects = list_all_projects(owner)
+    # Default sort: oldest first (matches the "oldest is /work-flow default" surface).
+    projects.sort(key=lambda p: p["createdAt"])
+
+    oldest = find_oldest_active(owner)
+    oldest_number = oldest["number"] if oldest else None
+
+    if args.json:
+        print(json.dumps({
+            "projects":      projects,
+            "oldest_active": oldest_number,
+        }, indent=2))
+        return
+
+    print(render_menu(projects, oldest_number, include_create_new=not args.no_create_new))
+
+
+if __name__ == "__main__":
+    main()

--- a/git-tools/interface/set_statuses.py
+++ b/git-tools/interface/set_statuses.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Apply a batch of project Status mutations in one shot.
+
+Reads a JSON array of moves on stdin:
+
+    [
+      {"item_id": "PVTI_...", "status": "Done"},
+      {"item_id": "PVTI_...", "status": "Backlog"}
+    ]
+
+Used by /triage to commit an approved batch after the user authorizes.
+"""
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "lib"))
+from project import query_project, set_item_statuses
+from github_client import load_config
+
+
+def main():
+    cfg = load_config()
+    owner = cfg["owner"]
+    project_number = int(os.environ.get("PROJECT_NUMBER", cfg["project_number"]))
+
+    payload = json.load(sys.stdin)
+    if not isinstance(payload, list):
+        print("ERROR: stdin must be a JSON array of {item_id, status} objects.", file=sys.stderr)
+        sys.exit(1)
+
+    moves = [(m["item_id"], m["status"]) for m in payload]
+    if not moves:
+        print("No moves to apply.")
+        return
+
+    project_data = query_project(owner, project_number)
+    applied = set_item_statuses(project_data, moves)
+    print(f"\033[32m✓\033[0m {applied} status mutation(s) applied.")
+
+
+if __name__ == "__main__":
+    main()

--- a/git-tools/lib/project.py
+++ b/git-tools/lib/project.py
@@ -144,6 +144,58 @@ def set_item_status_by_name(project_data, item_id, target_status):
     set_item_status(project_data["id"], item_id, status_field["id"], option["id"])
 
 
+def set_item_statuses(project_data, moves):
+    """Apply a batch of status mutations in a single aliased GraphQL request.
+
+    moves: iterable of (item_id, target_status_name) tuples.
+    Returns the number of mutations applied.
+
+    Resolves the Status field and option IDs once, then sends one GraphQL
+    request containing N aliased updateProjectV2ItemFieldValue mutations.
+    """
+    moves = list(moves)
+    if not moves:
+        return 0
+
+    status_field = next(
+        (n for n in project_data["fields"]["nodes"] if n.get("name") == "Status"), None
+    )
+    if not status_field:
+        print("ERROR: Status field not found.")
+        sys.exit(1)
+
+    option_id_by_name = {o["name"]: o["id"] for o in status_field["options"]}
+    for _, status_name in moves:
+        if status_name not in option_id_by_name:
+            valid = ", ".join(option_id_by_name)
+            print(f"ERROR: unknown status '{status_name}'. Valid: {valid}")
+            sys.exit(1)
+
+    var_decls = ["$projectId: ID!", "$fieldId: ID!"]
+    var_decls += [f"$itemId{i}: ID!" for i in range(len(moves))]
+    var_decls += [f"$optionId{i}: String!" for i in range(len(moves))]
+
+    bodies = []
+    for i in range(len(moves)):
+        bodies.append(
+            f"  m{i}: updateProjectV2ItemFieldValue(input: {{\n"
+            f"    projectId: $projectId\n"
+            f"    itemId: $itemId{i}\n"
+            f"    fieldId: $fieldId\n"
+            f"    value: {{ singleSelectOptionId: $optionId{i} }}\n"
+            f"  }}) {{ projectV2Item {{ id }} }}"
+        )
+    mutation = f"mutation({', '.join(var_decls)}) {{\n{chr(10).join(bodies)}\n}}"
+
+    variables = {"projectId": project_data["id"], "fieldId": status_field["id"]}
+    for i, (item_id, status_name) in enumerate(moves):
+        variables[f"itemId{i}"] = item_id
+        variables[f"optionId{i}"] = option_id_by_name[status_name]
+
+    github_client.graphql(mutation, variables)
+    return len(moves)
+
+
 # ── Project creation helpers ───────────────────────────────────────────────────
 
 def _get_owner_node_id(owner):

--- a/git-tools/lib/status_emojis.py
+++ b/git-tools/lib/status_emojis.py
@@ -1,0 +1,28 @@
+"""Single source of truth for the GitHub Project status emojis.
+
+Used by /new-task, /triage, /git-plan, and any future skill that surfaces
+statuses. Keep this in lockstep with the STATUS_* constants in project.py
+and the actual option names on the GitHub Project board.
+
+The lifecycle gradient (deferred → blocked → available → active → review →
+complete) is intentional — the colors carry semantic information at a glance.
+"""
+
+STATUS_EMOJI = {
+    "Backlog":     "⚫",
+    "Todo":        "🟠",
+    "Ready":       "⚪",
+    "In Progress": "🔵",
+    "Verify":      "🟡",
+    "Done":        "🟢",
+}
+
+
+def emoji_for(status: str) -> str:
+    """Return the emoji for a status name, or empty string if unknown."""
+    return STATUS_EMOJI.get(status, "")
+
+
+def legend(separator: str = " · ") -> str:
+    """Return a one-line legend like '⚫ Backlog · 🟠 Todo · ⚪ Ready · …'."""
+    return separator.join(f"{e} {n}" for n, e in STATUS_EMOJI.items())

--- a/git-tools/scripts/projects.py
+++ b/git-tools/scripts/projects.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""
+projects.py — Multi-project enumeration for /git-plan and /triage.
+
+Provides:
+- list_all_projects(owner)  → every projectsV2 with status_counts
+- find_oldest_active(owner) → oldest project (by createdAt) that has open items
+
+Single GraphQL query per call; status counts come from the returned items.
+"""
+import os
+import sys
+
+LIB = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "lib")
+sys.path.insert(0, LIB)
+import github_client
+
+
+_LIST_QUERY = """
+query($login: String!) {
+  user(login: $login) {
+    projectsV2(first: 50) {
+      nodes {
+        id number title url createdAt closed
+        items(first: 100) {
+          nodes {
+            content { ... on Issue { state } }
+            fieldValues(first: 5) {
+              nodes {
+                ... on ProjectV2ItemFieldSingleSelectValue {
+                  name
+                  field { ... on ProjectV2SingleSelectField { name } }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}"""
+
+
+def _status_counts(project_node):
+    """Tally Status field values across all items in a project node."""
+    counts = {}
+    for item in project_node.get("items", {}).get("nodes", []):
+        for fv in item.get("fieldValues", {}).get("nodes", []):
+            if fv.get("field", {}).get("name") == "Status" and fv.get("name"):
+                counts[fv["name"]] = counts.get(fv["name"], 0) + 1
+                break
+    return counts
+
+
+def _has_open_items(project_node):
+    return any(
+        (item.get("content") or {}).get("state", "").upper() == "OPEN"
+        for item in project_node.get("items", {}).get("nodes", [])
+    )
+
+
+def list_all_projects(owner):
+    """Return every projectsV2 for the owner.
+
+    Each entry: {id, number, title, url, createdAt, closed, status_counts,
+                 has_open_items}.
+    Closed projects are included; the caller decides whether to filter.
+    """
+    data = github_client.graphql(_LIST_QUERY, {"login": owner})
+    nodes = data["data"]["user"]["projectsV2"]["nodes"]
+    return [
+        {
+            "id":               p["id"],
+            "number":           p["number"],
+            "title":            p["title"],
+            "url":              p["url"],
+            "createdAt":        p["createdAt"],
+            "closed":           p.get("closed", False),
+            "status_counts":    _status_counts(p),
+            "has_open_items":   _has_open_items(p),
+        }
+        for p in nodes
+    ]
+
+
+def find_oldest_active(owner):
+    """Return the oldest (by createdAt) non-closed project with at least one open item.
+
+    Returns None if no project qualifies.
+    """
+    candidates = [
+        p for p in list_all_projects(owner)
+        if not p["closed"] and p["has_open_items"]
+    ]
+    if not candidates:
+        return None
+    candidates.sort(key=lambda p: p["createdAt"])
+    return candidates[0]

--- a/git-tools/tests/test_project_logic.py
+++ b/git-tools/tests/test_project_logic.py
@@ -1,11 +1,11 @@
 """Tests for project domain logic: items_by_status, set_item_status_by_name,
-loop_state (next_action branching), and wrap_labels layout."""
+set_item_statuses, loop_state (next_action branching), and wrap_labels layout."""
 import pytest
 from unittest.mock import patch, MagicMock
 from pathlib import Path
 
 from conftest import make_item, make_project_data
-from project import items_by_status, set_item_status_by_name
+from project import items_by_status, set_item_status_by_name, set_item_statuses
 from project_state import loop_state
 from list_prs import wrap_labels
 
@@ -110,6 +110,60 @@ class TestSetItemStatusByName:
         set_item_status_by_name(data, "PVTI_1", "Todo")
         _, _, _, option_id = mock_set.call_args[0]
         assert option_id == "opt_todo"
+
+
+# ── set_item_statuses (batch) ──────────────────────────────────────────────────
+
+class TestSetItemStatuses:
+    @patch("project.github_client.graphql")
+    def test_empty_moves_short_circuits(self, mock_graphql):
+        data = make_project_data([])
+        applied = set_item_statuses(data, [])
+        assert applied == 0
+        mock_graphql.assert_not_called()
+
+    @patch("project.github_client.graphql")
+    def test_single_move_uses_one_aliased_mutation(self, mock_graphql):
+        data = make_project_data([])
+        applied = set_item_statuses(data, [("PVTI_1", "Ready")])
+        assert applied == 1
+        # One GraphQL call, with m0 alias and the correct option id resolved.
+        assert mock_graphql.call_count == 1
+        mutation_str, variables = mock_graphql.call_args[0]
+        assert "m0:" in mutation_str
+        assert variables["itemId0"]   == "PVTI_1"
+        assert variables["optionId0"] == "opt_ready"
+        assert variables["projectId"] == "PVT_test"
+        assert variables["fieldId"]   == "field_status"
+
+    @patch("project.github_client.graphql")
+    def test_multiple_moves_batched_in_one_request(self, mock_graphql):
+        data = make_project_data([])
+        moves = [("PVTI_1", "Ready"), ("PVTI_2", "Todo"), ("PVTI_3", "Backlog")]
+        applied = set_item_statuses(data, moves)
+        assert applied == 3
+        # Still one GraphQL call — that's the whole point of the batch.
+        assert mock_graphql.call_count == 1
+        mutation_str, variables = mock_graphql.call_args[0]
+        for i in range(3):
+            assert f"m{i}:" in mutation_str
+        assert variables["itemId0"]   == "PVTI_1" and variables["optionId0"] == "opt_ready"
+        assert variables["itemId1"]   == "PVTI_2" and variables["optionId1"] == "opt_todo"
+        assert variables["itemId2"]   == "PVTI_3" and variables["optionId2"] == "opt_backlog"
+
+    @patch("project.github_client.graphql")
+    def test_unknown_status_exits_before_call(self, mock_graphql):
+        data = make_project_data([])
+        with pytest.raises(SystemExit):
+            set_item_statuses(data, [("PVTI_1", "NotARealStatus")])
+        mock_graphql.assert_not_called()
+
+    @patch("project.github_client.graphql")
+    def test_missing_status_field_exits(self, mock_graphql):
+        data = {"id": "PVT_test", "fields": {"nodes": []}, "items": {"nodes": []}}
+        with pytest.raises(SystemExit):
+            set_item_statuses(data, [("PVTI_1", "Ready")])
+        mock_graphql.assert_not_called()
 
 
 # ── loop_state / next_action ───────────────────────────────────────────────────

--- a/git-tools/tests/test_projects.py
+++ b/git-tools/tests/test_projects.py
@@ -1,0 +1,122 @@
+"""Tests for projects.py — multi-project enumeration."""
+from unittest.mock import patch
+
+from projects import list_all_projects, find_oldest_active
+
+
+def _project_node(number, title, created_at, *, closed=False, item_states=None, statuses=None):
+    """Build a minimal projectsV2 node for tests.
+
+    item_states: list of issue states ("OPEN" | "CLOSED") — one per item.
+    statuses: list of Status field values, one per item (parallel to item_states).
+    """
+    item_states = item_states or []
+    statuses = statuses or [None] * len(item_states)
+    items = []
+    for state, status in zip(item_states, statuses):
+        items.append({
+            "content": {"state": state} if state else None,
+            "fieldValues": {
+                "nodes": [{"name": status, "field": {"name": "Status"}}] if status else []
+            },
+        })
+    return {
+        "id":        f"PVT_{number}",
+        "number":    number,
+        "title":     title,
+        "url":       f"https://github.com/users/test/projects/{number}",
+        "createdAt": created_at,
+        "closed":    closed,
+        "items":     {"nodes": items},
+    }
+
+
+def _graphql_response(nodes):
+    return {"data": {"user": {"projectsV2": {"nodes": nodes}}}}
+
+
+# ── list_all_projects ──────────────────────────────────────────────────────────
+
+class TestListAllProjects:
+    @patch("projects.github_client.graphql")
+    def test_returns_each_project_with_status_counts(self, mock_graphql):
+        mock_graphql.return_value = _graphql_response([
+            _project_node(
+                1, "Alpha", "2026-01-01T00:00:00Z",
+                item_states=["OPEN", "OPEN", "CLOSED"],
+                statuses=["Ready", "Ready", "Done"],
+            ),
+            _project_node(2, "Beta", "2026-02-01T00:00:00Z", item_states=[], statuses=[]),
+        ])
+        result = list_all_projects("test-owner")
+        assert len(result) == 2
+        assert result[0]["title"] == "Alpha"
+        assert result[0]["status_counts"] == {"Ready": 2, "Done": 1}
+        assert result[0]["has_open_items"] is True
+        assert result[1]["status_counts"] == {}
+        assert result[1]["has_open_items"] is False
+
+    @patch("projects.github_client.graphql")
+    def test_empty_owner_yields_empty_list(self, mock_graphql):
+        mock_graphql.return_value = _graphql_response([])
+        assert list_all_projects("test-owner") == []
+
+    @patch("projects.github_client.graphql")
+    def test_closed_projects_included_but_flagged(self, mock_graphql):
+        mock_graphql.return_value = _graphql_response([
+            _project_node(1, "Old", "2025-01-01T00:00:00Z", closed=True,
+                          item_states=["OPEN"], statuses=["Ready"]),
+        ])
+        result = list_all_projects("test-owner")
+        assert result[0]["closed"] is True
+
+
+# ── find_oldest_active ─────────────────────────────────────────────────────────
+
+class TestFindOldestActive:
+    @patch("projects.github_client.graphql")
+    def test_picks_oldest_with_open_items(self, mock_graphql):
+        mock_graphql.return_value = _graphql_response([
+            _project_node(2, "Younger", "2026-03-01T00:00:00Z",
+                          item_states=["OPEN"], statuses=["Ready"]),
+            _project_node(1, "Older",   "2026-01-01T00:00:00Z",
+                          item_states=["OPEN"], statuses=["Todo"]),
+            _project_node(3, "Newest",  "2026-04-01T00:00:00Z",
+                          item_states=["OPEN"], statuses=["Backlog"]),
+        ])
+        result = find_oldest_active("test-owner")
+        assert result["number"] == 1
+        assert result["title"]  == "Older"
+
+    @patch("projects.github_client.graphql")
+    def test_skips_projects_without_open_items(self, mock_graphql):
+        mock_graphql.return_value = _graphql_response([
+            _project_node(1, "Done-Only", "2026-01-01T00:00:00Z",
+                          item_states=["CLOSED"], statuses=["Done"]),
+            _project_node(2, "Has-Open",  "2026-02-01T00:00:00Z",
+                          item_states=["OPEN"], statuses=["Ready"]),
+        ])
+        # Project 1 is older but has no open items — project 2 wins.
+        result = find_oldest_active("test-owner")
+        assert result["number"] == 2
+
+    @patch("projects.github_client.graphql")
+    def test_skips_closed_projects(self, mock_graphql):
+        mock_graphql.return_value = _graphql_response([
+            _project_node(1, "Archived", "2026-01-01T00:00:00Z",
+                          closed=True, item_states=["OPEN"], statuses=["Ready"]),
+            _project_node(2, "Active",   "2026-02-01T00:00:00Z",
+                          item_states=["OPEN"], statuses=["Ready"]),
+        ])
+        result = find_oldest_active("test-owner")
+        assert result["number"] == 2
+
+    @patch("projects.github_client.graphql")
+    def test_returns_none_when_no_qualifying_projects(self, mock_graphql):
+        mock_graphql.return_value = _graphql_response([
+            _project_node(1, "Closed",  "2026-01-01T00:00:00Z",
+                          closed=True, item_states=["OPEN"], statuses=["Ready"]),
+            _project_node(2, "Empty",   "2026-02-01T00:00:00Z",
+                          item_states=[], statuses=[]),
+        ])
+        assert find_oldest_active("test-owner") is None


### PR DESCRIPTION
Adds a project-wide triage skill that pulls every open item in a GitHub Project, reasons per item about dependencies and observable state, and applies status moves as an authorized batch via a single aliased GraphQL mutation. /git-plan's preflight is replaced with a multi-project selector that routes existing-project picks through /triage (or an extend sub-flow that adds new Epics/Issues to an existing project) while preserving the create-from-scratch path under "Create new project". The status emoji vocabulary is centralized in a new lib module so future skills render consistent indicators across the full lifecycle.