### PR TITLE
Fix token usage tracker glob for the workspace project dir

### DIFF
--- a/claude/recording/token_usage.py
+++ b/claude/recording/token_usage.py
@@ -14,8 +14,13 @@ import json
 import os
 from datetime import datetime
 
+# Claude Code stores each session's JSONL under a per-cwd "project" directory whose name is
+# the working-directory path slugified (every "/" becomes "-"). The launch directory has
+# moved into the workspace over time, so match any project dir for this workspace (and its
+# sub-repos) by substring rather than hardcoding one slug — keeps the tracker working when
+# the cwd changes again.
 JSONL_GLOBS = [
-    os.path.expanduser("~/.claude/projects/-home-ClaudeSpace/*.jsonl"),
+    os.path.expanduser("~/.claude/projects/*claude-workspace*/*.jsonl"),
     os.path.expanduser("~/.claude/sessions/*.jsonl"),
 ]
 


### PR DESCRIPTION
The token-usage tracker silently reported zeros because it globbed a hardcoded project-directory slug — the home directory — that no longer matches where session logs are stored. Claude Code names each session data directory after its launch working directory, which has since moved into the workspace, so the glob matched nothing. It now matches any workspace project directory by substring, so it picks up the real session files again and survives the working directory changing in future.