### PR TITLE
Scope active-project guard to per-repo

### DIFF
--- a/git-tools/lib/project.py
+++ b/git-tools/lib/project.py
@@ -330,8 +330,14 @@ mutation($projectId: ID!, $contentId: ID!) {
 
 # ── Active-project detection + advance-ready ──────────────────────────────────
 
-def find_active_project(owner):
-    """Return the first project with open issues, or None if all are clear."""
+def find_active_project(owner, repo=None):
+    """Return the first project with open issues, or None if all are clear.
+
+    When `repo` ("OWNER/REPO") is given, the guard is scoped per-repo: a project
+    counts as active only if it has open issues that live in that repo. This lets
+    each repo carry its own active project independently (e.g. a code repo and a
+    separate planning repo do not block each other).
+    """
     query = """
 query($login: String!, $first: Int!) {
   user(login: $login) {
@@ -340,7 +346,7 @@ query($login: String!, $first: Int!) {
         number title url
         items(first: 100) {
           nodes {
-            content { ... on Issue { state } }
+            content { ... on Issue { state repository { nameWithOwner } } }
           }
         }
       }
@@ -351,6 +357,10 @@ query($login: String!, $first: Int!) {
     for project in data["data"]["user"]["projectsV2"]["nodes"]:
         has_open = any(
             (item.get("content") or {}).get("state", "").upper() == "OPEN"
+            and (
+                repo is None
+                or ((item.get("content") or {}).get("repository") or {}).get("nameWithOwner") == repo
+            )
             for item in project["items"]["nodes"]
         )
         if has_open:

--- a/git-tools/scripts/git-plan.py
+++ b/git-tools/scripts/git-plan.py
@@ -75,9 +75,9 @@ def main():
 
     # ── Active-project guard ──────────────────────────────────────────────────
     if not args.project_number:
-        active = find_active_project(owner)
+        active = find_active_project(owner, repo)
         if active:
-            print(f"ERROR: An active project already has open issues.")
+            print(f"ERROR: An active project for {repo} already has open issues.")
             print(f"  #{active['number']}: {active['title']}")
             print(f"  {active['url']}")
             print()


### PR DESCRIPTION
The active-project guard previously treated all of an owner's projects as a single pool, so opening a board for a new repository was blocked whenever any other repo already had an open project. Scoping the guard to the target repository lets a code repo and a separate planning repo each hold their own active project independently. A project now counts as active only when it has open issues that actually live in the repository being planned.