### PR TITLE
Add the shot screenshot tool and /shot, /platform-content, /platform-logins skills

### DIFF
--- a/claude/skills/platform-content/SKILL.md
+++ b/claude/skills/platform-content/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: platform-content
+description: Replace files on the platform's shared PersistentVolume (the résumé served at /resume.pdf, and the quiz card decks) without an image rebuild. Use when the user wants to swap in a new résumé PDF or edit/replace card decks on the running cluster.
+---
+
+Replace content on the `platform-content` PersistentVolume in the running cluster.
+
+## When to use
+
+The user wants to update a file that is mounted from the volume rather than baked into an image —
+most often **a new résumé** (`/resume.pdf` on the home page), or **card decks** for the quiz. These
+live on the PVC precisely so they can change without a rebuild.
+
+Do NOT use this for code or manifests — those go through a normal build/deploy.
+
+## Run it
+
+```bash
+bash "$HOME/git-workspace/claude-workspace/platform-orchestration/k8s/pv-content.sh" <command>
+```
+
+Commands:
+
+| Command | Effect |
+| --- | --- |
+| `ls` | list what is on the volume (the résumé, and the card decks under `cards/`) |
+| `set-resume <local.pdf>` | replace `/resume.pdf`, then roll `home` so it is served |
+| `set-cards <dir \| one.yaml>` | copy a deck directory or a single deck onto the volume, then roll `quiz` |
+
+### Examples
+
+```bash
+bash .../pv-content.sh ls
+bash .../pv-content.sh set-resume ~/Documents/resume-2026.pdf
+bash .../pv-content.sh set-cards ~/git-workspace/claude-workspace/data-driven-quiz-server/cards
+```
+
+## How it works (so nothing surprises you)
+
+It brings up a throwaway `pv-writer` pod that mounts the same PVC read-write (the volume is mounted
+read-only into the real pods, so it cannot be written through them), copies the file in, tears the
+pod down, then **rolls the consuming deployment** — required because a replaced single file gets a new
+inode and the old subPath bind-mount would keep serving the old one. The script repoints the
+kubeconfig first (Colima/minikube forwarded-port quirk), so no manual setup is needed.
+
+## Output
+
+Prints the copied file's listing and the rollout status, ending in `done`. Errors are `ERROR: ...`
+lines — a missing file, a wrong extension (résumé must be `.pdf`), or a cluster that is down.

--- a/claude/skills/platform-logins/SKILL.md
+++ b/claude/skills/platform-logins/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: platform-logins
+description: List the identities registered with platform-auth — usernames, which are admins, and when each was last seen — read from platform-db in the running cluster. Use when the user asks which accounts exist or which username is theirs. It shows NO codes: codes are stored one-way and cannot be recovered.
+---
+
+List the platform-auth identities from the running cluster.
+
+## When to use
+
+The user asks "which accounts exist", "which username did I sign up as", "which one is my admin", or
+wants an overview of who has registered. It answers the *account* question, not the *credential* one.
+
+## The hard limit — say it plainly
+
+This tool shows **no codes, ever.** The auth service stores each code only as `HMAC-SHA256(pepper,
+code)` in `code_lookup`; the code itself is never kept in a readable form — not for a regular user,
+not for an admin (`AUTH_ADMINS` is a list of usernames, not codes). **A forgotten code cannot be
+recovered, only reset.** If the user needs to get back into an account whose code is lost, the answer
+is a code reset (a separate action that writes a new hash), or re-signing-up — not this tool.
+
+## Run it
+
+```bash
+python3 "$HOME/git-workspace/claude-workspace/platform-orchestration/k8s/logins.py"
+python3 "$HOME/git-workspace/claude-workspace/platform-orchestration/k8s/logins.py" --json
+```
+
+## Output
+
+A table, newest login first: `USERNAME`, an `ADMIN` star (★ when the username is in the live
+`AUTH_ADMINS`), `CREATED`, `LAST SEEN`, and the `ID` (the JWT `sub`). It ends with a count and a
+reminder that codes are not shown. `--json` gives the same data machine-readable.
+
+It reads the `identities` table via `psql` inside the `platform-db` pod and the admin list from the
+live `platform-auth` secret, repointing the kubeconfig first. Errors are `ERROR: ...` lines — most
+often a cluster that is down. Read-only: it never writes and never prints credential material.

--- a/claude/skills/shot/SKILL.md
+++ b/claude/skills/shot/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: shot
+description: Capture a headless-browser screenshot of a URL — the whole viewport, the full scrollable page, or one element's bounding box — for visual verification of a deployed or local web page. Supports mobile emulation, seeding a platform identity, and clicking a panel/tab open before the shot. Use whenever a change needs an actual visual check instead of hand-writing CDP glue.
+---
+
+Take a screenshot with the reusable tool instead of writing a one-off browser script.
+
+## When to use
+
+Any time you would otherwise hand-write a headless-Chromium + DevTools-protocol script to look at a
+page: verifying a deployed change on `andres.project-platform.me`, checking a locally-served build,
+confirming a component renders, comparing desktop vs mobile. If you just need the DOM/text, prefer
+`curl`; use this when the *rendered pixels* are what matter.
+
+## Run it
+
+```bash
+node "$HOME/git-workspace/claude-workspace/Claude-Project-Tooling/claude/tools/shot.mjs" \
+  --url <URL> --out <PATH.png> [options]
+```
+
+Then **Read the output PNG** to inspect it.
+
+### Options
+
+| Flag | Effect |
+| --- | --- |
+| `--url <url>` | page to load (required) |
+| `--out <path>` | PNG output path (required) |
+| `--selector <css>` | clip to this element's bounding box (else the viewport) |
+| `--width <px>` / `--height <px>` | viewport size (default 1460×1200) |
+| `--mobile` | emulate a 390px phone (scale 2, touch) |
+| `--identity <val>` | seed `localStorage['platform:identity']` before load: `guest`, `user`, `admin`, or a raw JSON string |
+| `--click <css[,css]>` | click these selectors in order before capturing (open a panel, switch a tab) |
+| `--eval <js>` | run JS in the page before capturing |
+| `--wait <ms>` | settle time after load and each action (default 4000) |
+| `--full` | capture the full scrollable page (ignored with `--selector`) |
+
+### Examples
+
+Verify a deployed component, clipped to it:
+```bash
+node .../shot.mjs --url https://andres.project-platform.me/ --out /tmp/tile.png --selector '.feat-banner'
+```
+
+Open the architecture panel, switch to the second diagram, clip to it (the exact flow that used to be
+a hand-written script):
+```bash
+node .../shot.mjs --url https://andres.project-platform.me/ --out /tmp/auth.png \
+  --identity guest --click '[data-act=architecture]' \
+  --eval "document.querySelectorAll('.arch-tab')[1].click()" --selector '.arch-slider'
+```
+
+Mobile view of a tile:
+```bash
+node .../shot.mjs --url https://andres.project-platform.me/ --out /tmp/m.png --mobile --selector '.feat'
+```
+
+## Output
+
+Prints `wrote <path> (WxH)` on success, or a `ERROR: ...` line to stderr. A missing `--selector`
+target, an unreachable page, or a browser that never starts each produce a labelled error. After a
+successful run, Read the PNG to actually look at it.

--- a/claude/tools/shot.mjs
+++ b/claude/tools/shot.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+// shot.mjs — one reusable headless-browser screenshot, so this stops being hand-written CDP glue
+// every time a change needs a visual check.
+//
+// Drives a headless Chromium/Brave over the DevTools protocol: navigate, optionally seed an identity,
+// optionally emulate a phone, optionally click things open, then capture — the whole viewport, the
+// full scrollable page, or the bounding box of one element.
+//
+// Usage:
+//   node shot.mjs --url <URL> --out <PATH> [options]
+//
+// Options:
+//   --url <url>          page to load                                        (required)
+//   --out <path>         PNG output path                                     (required)
+//   --selector <css>     clip to this element's bounding box (else viewport)
+//   --width <px>         viewport width                                      (default 1460)
+//   --height <px>        viewport height                                     (default 1200)
+//   --mobile             emulate a 390px phone (deviceScaleFactor 2, touch)
+//   --identity <val>     seed localStorage['platform:identity'] before load:
+//                          guest | admin | user | '<raw JSON>'
+//   --click <css[,css]>  click these selectors in order before capturing (open a panel, switch a tab)
+//   --eval <js>          run this JS in the page before capturing (power tool)
+//   --wait <ms>          settle time after load and after each action        (default 4000)
+//   --full               capture the full scrollable page (ignored with --selector)
+//   --browser <path>     browser binary (else auto-detected)
+//   --timeout <ms>       hard cap on the whole run                           (default 90000)
+//
+// Prints the output path and the captured pixel size, or a labelled ERROR: line for the caller.
+
+import { spawn, spawnSync } from 'node:child_process';
+import { writeFileSync, existsSync } from 'node:fs';
+
+const fail = (msg) => { console.error(`ERROR: ${msg}`); process.exit(1); };
+
+// ---- args -------------------------------------------------------------------
+const argv = process.argv.slice(2);
+const opt = {};
+for (let i = 0; i < argv.length; i++) {
+  const a = argv[i];
+  if (!a.startsWith('--')) continue;
+  const key = a.slice(2);
+  const flags = new Set(['mobile', 'full']);
+  opt[key] = flags.has(key) ? true : argv[++i];
+}
+if (!opt.url || !opt.out) fail('both --url and --out are required. See the header for usage.');
+
+const WIDTH = Number(opt.width || 1460);
+const HEIGHT = Number(opt.height || 1200);
+const WAIT = Number(opt.wait || 4000);
+const TIMEOUT = Number(opt.timeout || 90000);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ---- identity presets -------------------------------------------------------
+const IDENTITY = {
+  guest: '{"mode":"guest"}',
+  user: '{"mode":"user","username":"demo","admin":false}',
+  admin: '{"mode":"user","username":"demo","admin":true}',
+};
+const identityJson = opt.identity ? (IDENTITY[opt.identity] ?? opt.identity) : null;
+
+// ---- find a browser ---------------------------------------------------------
+function findBrowser() {
+  if (opt.browser) return opt.browser;
+  const candidates = [
+    '/usr/bin/brave-browser', '/usr/bin/chromium', '/usr/bin/chromium-browser',
+    '/usr/bin/google-chrome', '/usr/bin/google-chrome-stable',
+  ];
+  for (const c of candidates) if (existsSync(c)) return c;
+  // last resort: ask the shell
+  for (const name of ['brave-browser', 'chromium', 'google-chrome']) {
+    const w = spawnSync('which', [name]);
+    if (w.status === 0) return w.stdout.toString().trim();
+  }
+  fail('no headless browser found (looked for brave-browser, chromium, google-chrome). Pass --browser.');
+}
+
+// ---- CDP over the websocket -------------------------------------------------
+async function main() {
+  const browser = findBrowser();
+  // A per-run port and profile dir so concurrent shots never collide. Math.random is fine here — this
+  // is a one-shot CLI, not the resumable workflow runtime.
+  const port = 9200 + Math.floor(Math.random() * 700);
+  const profile = `/tmp/shot-${Date.now()}-${port}`;
+  const args = [
+    '--headless=new', '--disable-gpu', '--no-sandbox', `--user-data-dir=${profile}`,
+    `--remote-debugging-port=${port}`, `--window-size=${WIDTH},${HEIGHT}`, 'about:blank',
+  ];
+  const proc = spawn(browser, args, { stdio: 'ignore' });
+  const killAll = () => { try { proc.kill('SIGKILL'); } catch {} };
+  const hardStop = setTimeout(() => { killAll(); fail(`timed out after ${TIMEOUT}ms`); }, TIMEOUT);
+
+  // discover the page target
+  let wsUrl = null;
+  for (let i = 0; i < 80 && !wsUrl; i++) {
+    try {
+      const list = await fetch(`http://127.0.0.1:${port}/json/list`).then((r) => r.json());
+      wsUrl = list.find((t) => t.type === 'page')?.webSocketDebuggerUrl ?? null;
+    } catch { /* not up yet */ }
+    if (!wsUrl) await sleep(250);
+  }
+  if (!wsUrl) { killAll(); fail('the browser never exposed a CDP endpoint'); }
+
+  const ws = new WebSocket(wsUrl);
+  await new Promise((res, rej) => { ws.onopen = res; ws.onerror = () => rej(new Error('ws')); });
+  let id = 0;
+  const pending = new Map();
+  ws.onmessage = (m) => {
+    const x = JSON.parse(m.data);
+    if (x.id && pending.has(x.id)) { pending.get(x.id)(x.result); pending.delete(x.id); }
+  };
+  const send = (method, params = {}) =>
+    new Promise((res) => { const n = ++id; pending.set(n, res); ws.send(JSON.stringify({ id: n, method, params })); });
+  const evaluate = (expression) =>
+    send('Runtime.evaluate', { returnByValue: true, awaitPromise: true, expression }).then((r) => r.result?.value);
+
+  await send('Page.enable');
+  await send('Runtime.enable');
+
+  if (opt.mobile) {
+    await send('Emulation.setDeviceMetricsOverride', { width: 390, height: 1500, deviceScaleFactor: 2, mobile: true });
+  }
+  if (identityJson) {
+    // A quoted, escaped literal so any characters in the JSON survive the round-trip.
+    const src = `localStorage.setItem('platform:identity', ${JSON.stringify(identityJson)});`;
+    await send('Page.addScriptToEvaluateOnNewDocument', { source: src });
+  }
+
+  await send('Page.navigate', { url: opt.url });
+  await sleep(WAIT);
+
+  if (opt.click) {
+    for (const sel of String(opt.click).split(',').map((s) => s.trim()).filter(Boolean)) {
+      const clicked = await evaluate(
+        `(()=>{const el=document.querySelector(${JSON.stringify(sel)});if(!el)return false;el.click();return true;})()`,
+      );
+      if (!clicked) console.error(`  note: --click selector not found: ${sel}`);
+      await sleep(WAIT);
+    }
+  }
+  if (opt.eval) { await evaluate(String(opt.eval)); await sleep(WAIT); }
+
+  // Where to clip.
+  let clip;
+  if (opt.selector) {
+    clip = await evaluate(
+      `(()=>{const e=document.querySelector(${JSON.stringify(opt.selector)});if(!e)return null;` +
+      `const r=e.getBoundingClientRect();return{x:Math.max(0,r.x-4),y:Math.max(0,r.y-4),width:r.width+8,height:r.height+8,scale:1};})()`,
+    );
+    if (!clip) { killAll(); fail(`--selector matched no element: ${opt.selector}`); }
+  }
+
+  const { data } = await send('Page.captureScreenshot', {
+    format: 'png',
+    captureBeyondViewport: Boolean(opt.selector || opt.full),
+    clip: clip || undefined,
+  });
+  if (!data) { killAll(); fail('the browser returned no image data'); }
+  writeFileSync(opt.out, Buffer.from(data, 'base64'));
+
+  const w = clip ? Math.round(clip.width) : WIDTH;
+  const h = clip ? Math.round(clip.height) : HEIGHT;
+  console.log(`wrote ${opt.out} (${w}x${h})`);
+
+  clearTimeout(hardStop);
+  ws.close();
+  killAll();
+  process.exit(0);
+}
+
+main().catch((e) => fail(e?.message || String(e)));


### PR DESCRIPTION
Adds a reusable headless-screenshot CLI (`claude/tools/shot.mjs`) that replaces the one-off CDP scripts used for visual verification — it clips to an element, emulates mobile, seeds a platform identity, and can click a panel/tab open before capturing. Ships three skills alongside it: `/shot` wraps the tool; `/platform-content` replaces the résumé and card decks on the running cluster's PersistentVolume; and `/platform-logins` lists the platform-auth identities (usernames, admin flag, timestamps — no codes, which are stored one-way and cannot be recovered). The two platform skills call scripts that live with the cluster in platform-orchestration.