### PR TITLE
Point the platform ops skills at the private platform-ops repo

### DIFF
--- a/claude/skills/platform-content/SKILL.md
+++ b/claude/skills/platform-content/SKILL.md
@@ -16,7 +16,7 @@ Do NOT use this for code or manifests — those go through a normal build/deploy
 ## Run it
 
 ```bash
-bash "$HOME/git-workspace/claude-workspace/platform-orchestration/k8s/pv-content.sh" <command>
+bash "$HOME/git-workspace/claude-workspace/platform-ops/pv-content.sh" <command>
 ```
 
 Commands:

--- a/claude/skills/platform-logins/SKILL.md
+++ b/claude/skills/platform-logins/SKILL.md
@@ -21,8 +21,8 @@ is a code reset (a separate action that writes a new hash), or re-signing-up —
 ## Run it
 
 ```bash
-python3 "$HOME/git-workspace/claude-workspace/platform-orchestration/k8s/logins.py"
-python3 "$HOME/git-workspace/claude-workspace/platform-orchestration/k8s/logins.py" --json
+python3 "$HOME/git-workspace/claude-workspace/platform-ops/logins.py"
+python3 "$HOME/git-workspace/claude-workspace/platform-ops/logins.py" --json
 ```
 
 ## Output


### PR DESCRIPTION
`logins.py` and `pv-content.sh` moved from the public platform-orchestration repo to the private `platform-ops`; the `/platform-logins` and `/platform-content` skills now invoke them from the new location.