### PR TITLE
A visual regression net, and three bugs in the tool it is built on

### DIFF
--- a/claude/skills/platform-content/SKILL.md
+++ b/claude/skills/platform-content/SKILL.md
@@ -37,13 +37,36 @@ bash .../pv-content.sh set-cards ~/git-workspace/claude-workspace/data-driven-qu
 
 ## How it works (so nothing surprises you)
 
-It brings up a throwaway `pv-writer` pod that mounts the same PVC read-write (the volume is mounted
-read-only into the real pods, so it cannot be written through them), copies the file in, tears the
-pod down, then **rolls the consuming deployment** — required because a replaced single file gets a new
-inode and the old subPath bind-mount would keep serving the old one. The script repoints the
-kubeconfig first (Colima/minikube forwarded-port quirk), so no manual setup is needed.
+It brings up a throwaway `pv-writer` pod that mounts the same PVC read-write, copies the file in, and
+tears the pod down. The script repoints the kubeconfig first (Colima/minikube forwarded-port quirk), so
+no manual setup is needed.
+
+**`set-cards` rolls the quiz; `set-resume` rolls nothing.** The quiz builds its decks once at startup,
+so a new deck on the volume changes nothing until that pod restarts — and note a malformed deck fails
+the quiz's *next* boot, not the copy. The résumé needs no roll: home reads it per request from the
+volume's directory mount, so the next request already serves the new file.
+
+(The résumé used to need a roll, and the reason is worth keeping: it arrived as a subPath single-file
+mount, which is a bind mount pinned to the file's inode at container start. A replaced file has a new
+inode and the mount kept serving the old one. home now reads the directory mount, which resolves by
+name on every lookup.)
+
+## There is an HTTP path too
+
+home serves an admin-only `PUT /api/content/<path>` for the same volume — no kubectl, no pod:
+
+```bash
+curl -X PUT https://andres.project-platform.me/api/content/resume.pdf \
+     -H "Authorization: Bearer <admin token>" \
+     -H 'Content-Type: application/pdf' --data-binary @resume.pdf
+```
+
+Prefer it for routine swaps. It accepts only `resume.pdf` and `cards/<name>.yaml` (an allowlist —
+`platform-version.json` and anything else are refused), and writes atomically. This script remains the
+escape hatch: it works when home is broken, unbuilt or mid-rollout, and it is the only way to reach
+paths the allowlist refuses.
 
 ## Output
 
-Prints the copied file's listing and the rollout status, ending in `done`. Errors are `ERROR: ...`
-lines — a missing file, a wrong extension (résumé must be `.pdf`), or a cluster that is down.
+Prints the copied file's listing and, for `set-cards`, the rollout status — ending in `done`. Errors are
+`ERROR: ...` lines — a missing file, a wrong extension (résumé must be `.pdf`), or a cluster that is down.

--- a/claude/tools/shot.mjs
+++ b/claude/tools/shot.mjs
@@ -22,13 +22,15 @@
 //   --eval <js>          run this JS in the page before capturing (power tool)
 //   --wait <ms>          settle time after load and after each action        (default 4000)
 //   --full               capture the full scrollable page (ignored with --selector)
+//   --reduced-motion     emulate prefers-reduced-motion: reduce — freezes CSS animations, which is
+//                        what makes a pixel baseline of an animated view possible at all
 //   --browser <path>     browser binary (else auto-detected)
 //   --timeout <ms>       hard cap on the whole run                           (default 90000)
 //
 // Prints the output path and the captured pixel size, or a labelled ERROR: line for the caller.
 
 import { spawn, spawnSync } from 'node:child_process';
-import { writeFileSync, existsSync } from 'node:fs';
+import { writeFileSync, existsSync, readFileSync, rmSync } from 'node:fs';
 
 const fail = (msg) => { console.error(`ERROR: ${msg}`); process.exit(1); };
 
@@ -39,7 +41,7 @@ for (let i = 0; i < argv.length; i++) {
   const a = argv[i];
   if (!a.startsWith('--')) continue;
   const key = a.slice(2);
-  const flags = new Set(['mobile', 'full']);
+  const flags = new Set(['mobile', 'full', 'reduced-motion']);
   opt[key] = flags.has(key) ? true : argv[++i];
 }
 if (!opt.url || !opt.out) fail('both --url and --out are required. See the header for usage.');
@@ -77,17 +79,54 @@ function findBrowser() {
 // ---- CDP over the websocket -------------------------------------------------
 async function main() {
   const browser = findBrowser();
-  // A per-run port and profile dir so concurrent shots never collide. Math.random is fine here — this
-  // is a one-shot CLI, not the resumable workflow runtime.
-  const port = 9200 + Math.floor(Math.random() * 700);
-  const profile = `/tmp/shot-${Date.now()}-${port}`;
+  const profile = `/tmp/shot-${process.pid}-${Date.now()}`;
+  // PORT 0, NOT A GUESS. The browser picks a free port and writes it to DevToolsActivePort in its own
+  // profile dir; we read it back from there.
+  //
+  // This used to be `9200 + random(700)` and then talk to whatever answered on that port — which is not
+  // necessarily the browser we just spawned. Other tools on this machine open debug ports in the same
+  // range (resume-lab's build.mjs uses 9300 + random(500)), and headless browsers outlive their parent
+  // when a run dies. The failure is silent and awful: you attach to a STRANGER's browser, drive it, and
+  // screenshot its page with its emulation still set. Caught red-handed — a `--width 1200` shot came back
+  // 390x1500, the exact metrics of a mobile run whose browser had not exited. A screenshot tool that can
+  // quietly photograph the wrong browser is worse than no screenshot tool, and a baseline captured that
+  // way would be worse still.
   const args = [
     '--headless=new', '--disable-gpu', '--no-sandbox', `--user-data-dir=${profile}`,
-    `--remote-debugging-port=${port}`, `--window-size=${WIDTH},${HEIGHT}`, 'about:blank',
+    '--remote-debugging-port=0', `--window-size=${WIDTH},${HEIGHT}`, 'about:blank',
   ];
-  const proc = spawn(browser, args, { stdio: 'ignore' });
-  const killAll = () => { try { proc.kill('SIGKILL'); } catch {} };
+  // `detached` makes the child a PROCESS GROUP LEADER, which is the only reason killAll below can
+  // actually reap it. A browser is not one process: brave forks a zygote and a renderer per tab, and
+  // SIGKILL on the direct child leaves the rest orphaned and running — holding their debug port open.
+  // This leaked ~4 processes on EVERY shot ever taken; the machine had 406 of them alive when it was
+  // found, which is also what made the port guessing above collide in the first place. Two bugs, one
+  // cause.
+  const proc = spawn(browser, args, { stdio: 'ignore', detached: true });
+  let reaped = false;
+  const killAll = () => {
+    if (reaped) return;
+    reaped = true;
+    // Negative pid = the whole process group. This is the line that actually ends the browser.
+    try { process.kill(-proc.pid, 'SIGKILL'); } catch {}
+    try { proc.kill('SIGKILL'); } catch {}
+    try { rmSync(profile, { recursive: true, force: true }); } catch {}
+  };
+  // Cover the paths that are not the happy one: an uncaught throw, a Ctrl-C, a parent that just ends.
+  process.on('exit', killAll);
+  process.on('SIGINT', () => { killAll(); process.exit(130); });
+  process.on('SIGTERM', () => { killAll(); process.exit(143); });
   const hardStop = setTimeout(() => { killAll(); fail(`timed out after ${TIMEOUT}ms`); }, TIMEOUT);
+
+  // The port our browser actually got. First line of the file is the port, second the browser ws path.
+  let port = null;
+  for (let i = 0; i < 120 && !port; i++) {
+    try {
+      const line = readFileSync(`${profile}/DevToolsActivePort`, 'utf8').split('\n')[0].trim();
+      if (line) port = Number(line);
+    } catch { /* not written yet */ }
+    if (!port) await sleep(250);
+  }
+  if (!port) { killAll(); fail('the browser never wrote DevToolsActivePort — it did not start'); }
 
   // discover the page target
   let wsUrl = null;
@@ -118,6 +157,18 @@ async function main() {
 
   if (opt.mobile) {
     await send('Emulation.setDeviceMetricsOverride', { width: 390, height: 1500, deviceScaleFactor: 2, mobile: true });
+  }
+  /* Ask the PAGE to hold still, rather than trying to time it.
+     An animating view cannot have a pixel baseline: the quiz's garden has falling particles and
+     animated animals, so two captures of an unchanged page differ by thousands of pixels and every
+     check cries wolf. Sleeping longer does not help — there is no frame at which an infinite animation
+     is "done". These apps already answer this exact question for real users, via
+     `@media (prefers-reduced-motion: reduce) { animation: none }`, so the honest move is to be a user
+     who asked for that. It freezes what the app itself agrees is decoration and touches nothing else. */
+  if (opt['reduced-motion']) {
+    await send('Emulation.setEmulatedMedia', {
+      features: [{ name: 'prefers-reduced-motion', value: 'reduce' }],
+    });
   }
   if (identityJson) {
     // A quoted, escaped literal so any characters in the JSON survive the round-trip.
@@ -155,13 +206,26 @@ async function main() {
     clip: clip || undefined,
   });
   if (!data) { killAll(); fail('the browser returned no image data'); }
-  writeFileSync(opt.out, Buffer.from(data, 'base64'));
+  const png = Buffer.from(data, 'base64');
+  writeFileSync(opt.out, png);
 
-  const w = clip ? Math.round(clip.width) : WIDTH;
-  const h = clip ? Math.round(clip.height) : HEIGHT;
-  console.log(`wrote ${opt.out} (${w}x${h})`);
+  // The size is read back out of the PNG's own IHDR, not recomputed from what we asked for.
+  //
+  // It used to print WIDTH x HEIGHT — the defaults — whenever there was no --selector, which was wrong
+  // in every interesting case: --mobile overrides the metrics to 390x1500 at 2x, and --full captures the
+  // whole scrollable page. A mobile full-page shot reported `1460x1200` for a file that was actually
+  // 780x10796, so the one line telling you what you captured was the one line you could not trust.
+  // IHDR is bytes 16..23 of every PNG, big-endian, and it describes the file that now exists.
+  const w = png.readUInt32BE(16);
+  const h = png.readUInt32BE(20);
+  const scale = opt.mobile ? 2 : 1;
+  const css = scale > 1 ? `, ${Math.round(w / scale)}x${Math.round(h / scale)} CSS @${scale}x` : '';
+  console.log(`wrote ${opt.out} (${w}x${h}${css})`);
 
   clearTimeout(hardStop);
+  // Ask it to leave before making it. Browser.close lets brave tear its own children down cleanly;
+  // killAll is the backstop for when it will not, and for every path that never gets here.
+  try { await Promise.race([send('Browser.close'), sleep(2000)]); } catch {}
   ws.close();
   killAll();
   process.exit(0);

--- a/claude/tools/shots.mjs
+++ b/claude/tools/shots.mjs
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+// shots.mjs — manifest-driven visual baselines: capture a set of screenshots, and fail when they change.
+//
+// WHY THIS EXISTS. The platform's three front-ends have zero layout test coverage, and that is not an
+// oversight — it is structural. All three test under happy-dom, which has no layout engine, so
+// getBoundingClientRect returns zeros and geometry CANNOT be asserted there. Every layout bug the
+// platform has shipped was therefore invisible to CI by construction: a garden with a quarter of itself
+// unreachable, a diagram whose labels render at 3px, a table clipped instead of scrolled. A rendered
+// screenshot is the only artefact that can see any of them.
+//
+// This is deliberately NOT a general visual-regression framework. It is a list of views, a folder of
+// PNGs, and a diff.
+//
+// Usage:
+//   node shots.mjs --manifest <file> --update        # write/refresh the baselines
+//   node shots.mjs --manifest <file> --check         # compare; non-zero exit on any change
+//   node shots.mjs --manifest <file> --check --only garden-mobile
+//
+// Options:
+//   --manifest <file>    JSON describing the shots                          (required)
+//   --update | --check   what to do                                         (required, one of)
+//   --base-url <url>     override the manifest's baseUrl (e.g. a local preview)
+//   --only <name>        just this one shot
+//   --tolerance <n>      default fraction of pixels allowed to differ       (default 0.001)
+//
+// Manifest shape — paths are relative to the manifest's own directory:
+//   {
+//     "baseUrl": "http://localhost:3000",
+//     "dir": "test/shots",
+//     "shots": [
+//       { "name": "garden-mobile", "path": "/garden", "selector": ".boardwrap",
+//         "mobile": true, "identity": "user" },
+//       { "name": "arch-cicd", "path": "/", "mobile": true, "identity": "guest",
+//         "click": "[data-act=architecture]",
+//         "eval": "document.querySelectorAll('.arch-tab')[1].click()",
+//         "selector": ".arch-slider", "tolerance": 0.005 }
+//     ]
+//   }
+//
+// Every key besides name/path maps straight onto a shot.mjs flag — this file owns no browser logic. It
+// SPAWNS shot.mjs rather than importing it, so there is exactly one place that knows how to drive a
+// browser, and a fix there (a leaked process, a guessed port) is a fix here for free.
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SHOT = join(HERE, 'shot.mjs');
+
+const fail = (msg) => { console.error(`ERROR: ${msg}`); process.exit(1); };
+
+// ---- args -------------------------------------------------------------------
+const argv = process.argv.slice(2);
+const opt = {};
+for (let i = 0; i < argv.length; i++) {
+  if (!argv[i].startsWith('--')) continue;
+  const key = argv[i].slice(2);
+  opt[key] = new Set(['update', 'check']).has(key) ? true : argv[++i];
+}
+if (!opt.manifest) fail('--manifest is required. See the header for the shape.');
+if (!opt.update && !opt.check) fail('pass --update (write baselines) or --check (compare against them).');
+if (opt.update && opt.check) fail('--update and --check are opposites; pass one.');
+
+const manifestPath = resolve(opt.manifest);
+if (!existsSync(manifestPath)) fail(`no manifest at ${manifestPath}`);
+let manifest;
+try {
+  manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+} catch (e) {
+  fail(`manifest is not valid JSON: ${e.message}`);
+}
+const root = dirname(manifestPath);
+const baseUrl = String(opt['base-url'] || manifest.baseUrl || '').replace(/\/+$/, '');
+if (!baseUrl) fail('no baseUrl: put one in the manifest or pass --base-url');
+const dir = resolve(root, manifest.dir || 'shots');
+const defaultTolerance = Number(opt.tolerance ?? 0.001);
+const shots = (manifest.shots || []).filter((s) => !opt.only || s.name === opt.only);
+if (!shots.length) fail(opt.only ? `no shot named ${opt.only}` : 'the manifest lists no shots');
+
+// ---- capture ----------------------------------------------------------------
+/** One shot, via shot.mjs. Returns the PNG path, or throws with shot.mjs's own error text. */
+function capture(shot, out) {
+  const args = ['--url', `${baseUrl}${shot.path ?? '/'}`, '--out', out];
+  // Reduced motion is the DEFAULT here, opt-out rather than opt-in: a baseline of a view that moves on
+  // its own is not a baseline. Set "reduced-motion": false on a shot that is specifically about motion.
+  if (shot['reduced-motion'] !== false) args.push('--reduced-motion');
+  for (const k of ['selector', 'identity', 'click', 'eval', 'wait', 'width', 'height']) {
+    if (shot[k] !== undefined) args.push(`--${k}`, String(shot[k]));
+  }
+  for (const k of ['mobile', 'full', 'reduced-motion']) if (shot[k]) args.push(`--${k}`);
+  const r = spawnSync('node', [SHOT, ...args], { encoding: 'utf8' });
+  if (r.status !== 0) {
+    throw new Error((r.stderr || r.stdout || `shot.mjs exited ${r.status}`).trim().split('\n').pop());
+  }
+  return out;
+}
+
+const size = (png) => {
+  const b = readFileSync(png);
+  return { w: b.readUInt32BE(16), h: b.readUInt32BE(20) };
+};
+
+/**
+ * Differing pixels between two PNGs, via ImageMagick.
+ *
+ * A size change is reported as its own thing rather than as a pixel count, and that is the point: for
+ * the bugs this exists to catch, the SIZE is the symptom. A diagram that collapsed from 1720px tall to
+ * 217px, a board that stopped overflowing — those are size changes, and a pixel metric on mismatched
+ * dimensions is either an error or a meaningless number.
+ */
+function compare(a, b, diffOut) {
+  const sa = size(a);
+  const sb = size(b);
+  if (sa.w !== sb.w || sa.h !== sb.h) {
+    return { changed: true, why: `size ${sa.w}x${sa.h} -> ${sb.w}x${sb.h}` };
+  }
+  // -metric AE counts absolute differing pixels; -fuzz absorbs antialiasing noise. compare exits 1 when
+  // the images differ, which is not an error here — it is the answer.
+  const r = spawnSync('compare', ['-metric', 'AE', '-fuzz', '1%', a, b, diffOut], { encoding: 'utf8' });
+  if (r.error) return { changed: true, why: 'ImageMagick `compare` not found — install it to diff' };
+
+  // PARSE THE PARENTHESISED COUNT, and do not get clever.
+  //
+  // ImageMagick 7 Q16 reports AE as "<count*65535> (<count>)" — e.g. `65535 (1)` for one differing
+  // pixel; other builds print a bare "<count>". The first number is the count scaled by the quantum
+  // range, so dividing by 65535 would be wrong on a Q8 build. Verified against deliberate 1/100/900-px
+  // diffs on 7.1.1-47 Q16-HDRI.
+  //
+  // This is worth a comment because the naive parse — strip everything that is not a digit or a dot —
+  // silently turns "1.38672e+08" into "1.3867208" by eating the exponent. That yields ~1 differing
+  // pixel for a diff of 2116, which is under every sane tolerance, so the checker reports `ok` for any
+  // change at all. A regression net that always passes is worse than none: it is a green light nobody
+  // re-examines. It shipped that way for exactly one test run.
+  const err = (r.stderr || '').trim();
+  const paren = err.match(/\(([\d.eE+-]+)\)\s*$/);
+  const n = Number(paren ? paren[1] : err.split(/\s+/)[0]);
+  if (!Number.isFinite(n)) return { changed: true, why: `could not read compare's output: "${err}"` };
+  const total = sa.w * sa.h;
+  return { changed: false, pixels: n, total, ratio: total ? n / total : 0 };
+}
+
+// ---- go ---------------------------------------------------------------------
+mkdirSync(dir, { recursive: true });
+const tmp = join('/tmp', `shots-${process.pid}`);
+mkdirSync(tmp, { recursive: true });
+
+let failed = 0;
+let updated = 0;
+console.log(`${opt.update ? 'updating' : 'checking'} ${shots.length} shot(s) against ${baseUrl}`);
+
+for (const shot of shots) {
+  if (!shot.name) fail('every shot needs a "name"');
+  const baseline = join(dir, `${shot.name}.png`);
+  const label = shot.name.padEnd(28);
+
+  if (opt.update) {
+    try {
+      capture(shot, baseline);
+      const { w, h } = size(baseline);
+      console.log(`  ${label} baseline ${w}x${h}`);
+      updated++;
+    } catch (e) {
+      console.error(`  ${label} FAILED: ${e.message}`);
+      failed++;
+    }
+    continue;
+  }
+
+  // --check
+  if (!existsSync(baseline)) {
+    console.error(`  ${label} NO BASELINE — run --update first`);
+    failed++;
+    continue;
+  }
+  const fresh = join(tmp, `${shot.name}.png`);
+  let cmp;
+  try {
+    capture(shot, fresh);
+    cmp = compare(baseline, fresh, join(dir, `${shot.name}.diff.png`));
+  } catch (e) {
+    console.error(`  ${label} FAILED: ${e.message}`);
+    failed++;
+    continue;
+  }
+  const tol = Number(shot.tolerance ?? defaultTolerance);
+  if (cmp.why) {
+    console.error(`  ${label} CHANGED: ${cmp.why}`);
+    failed++;
+  } else if (cmp.ratio > tol) {
+    const pct = (cmp.ratio * 100).toFixed(3);
+    console.error(`  ${label} CHANGED: ${cmp.pixels} px (${pct}% > ${(tol * 100).toFixed(3)}%) — see ${shot.name}.diff.png`);
+    failed++;
+  } else {
+    // A clean shot leaves no diff image behind to confuse the next reader.
+    rmSync(join(dir, `${shot.name}.diff.png`), { force: true });
+    console.log(`  ${label} ok`);
+  }
+}
+
+rmSync(tmp, { recursive: true, force: true });
+
+if (opt.update) {
+  console.log(`${updated} baseline(s) written to ${dir}`);
+  process.exit(failed ? 1 : 0);
+}
+if (failed) {
+  console.error(`\n${failed} shot(s) changed. Look at the diff PNGs; if the change is intended, re-run with --update.`);
+  process.exit(1);
+}
+console.log('all shots match their baselines');


### PR DESCRIPTION
The platform's three front-ends have no layout test coverage, and it is structural rather than neglect: all three test under happy-dom, which has no layout engine, so getBoundingClientRect returns zeros and geometry cannot be asserted at all - every layout bug the platform has shipped was invisible to CI by construction. shots.mjs is the only kind of net that can see them: a manifest of views, a folder of PNGs, and a diff, spawning shot.mjs so exactly one file knows how to drive a browser. Building it surfaced three faults in shot.mjs itself, each found only by trying to verify the one before: it reported the size from its own defaults and claimed 1460x1200 for a file that was really 780x10796; it picked a random debug port then talked to whatever answered, and was caught photographing another run's browser with that run's phone emulation still applied; and it reaped only its direct child, orphaning about four processes per shot - 406 were alive on this machine - which is what left the ports occupied for the second bug to find. The AE parse is commented at length because the naive version ate a scientific-notation exponent and reported ok for a 2116-pixel change, and a net that always passes is worse than no net at all.